### PR TITLE
Fix throughput for boto3-crt & cli-crt

### DIFF
--- a/runners/s3-benchrunner-python/runner/__init__.py
+++ b/runners/s3-benchrunner-python/runner/__init__.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 import io
 import json
+import math
 import os
 import sys
 
@@ -33,6 +34,10 @@ def bytes_to_megabit(bytes: int) -> float:
 
 def bytes_to_gigabit(bytes: int) -> float:
     return (bytes * 8) / 1_000_000_000.0
+
+
+def gigabit_to_bytes(gigabit: float) -> int:
+    return math.ceil((gigabit * 1_000_000_000.0) / 8.0)
 
 
 @dataclass

--- a/runners/s3-benchrunner-python/runner/cli.py
+++ b/runners/s3-benchrunner-python/runner/cli.py
@@ -39,8 +39,12 @@ class CliBenchmarkRunner(BenchmarkRunner):
         lines = ['[default]',
                  's3 =']
         if self.use_crt:
-            lines += ['  preferred_transfer_client = crt',
-                      f'  target_throughput = {self.config.target_throughput_Gbps} Gb/s']
+            lines += ['  preferred_transfer_client = crt']
+
+            # target_bandwidth can't be a float, so use Mb/s instead of Gb/s
+            megabits = int(self.config.target_throughput_Gbps * 1000)
+            lines += [f'  target_bandwidth = {megabits} Mb/s']
+
         else:
             lines += ['  preferred_transfer_client = default']
 
@@ -127,6 +131,10 @@ class CliBenchmarkRunner(BenchmarkRunner):
 
         # Add common options, used by all commands
         cmd += ['--region', self.config.region]
+
+        if not self.config.verbose:
+            # Progress callbacks may have performance impact
+            cmd += ['--quiet']
 
         # As of Sept 2023, can't pick checksum for: aws s3 cp
         if self.config.checksum:


### PR DESCRIPTION
* Fix throughput settings for boto3-crt and cli-crt.
  * I wasn't setting this properly for either, which kept us at 5Gb/s
* Honor benchmark's `checksum` setting
  * NOTE: boto3 and cli will do some kind of checksum, even if we don't explicitly tell them to


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
