### PR TITLE
Limit concurrency in aws-crt-python benchmark

### DIFF
--- a/runners/s3-benchrunner-python/runner/__init__.py
+++ b/runners/s3-benchrunner-python/runner/__init__.py
@@ -106,6 +106,10 @@ class BenchmarkRunner:
     def run(self):
         raise NotImplementedError()
 
+    def _verbose(self, msg):
+        if self.config.verbose:
+            print(msg)
+
     def _new_iostream_to_upload_from_ram(self, size: int) -> io.BytesIO:
         """Return new BytesIO stream, to use when uploading from RAM"""
         # use memoryview to avoid creating a copy of the (possibly very large) underlying bytes

--- a/runners/s3-benchrunner-python/runner/boto3.py
+++ b/runners/s3-benchrunner-python/runner/boto3.py
@@ -60,10 +60,6 @@ class Boto3BenchmarkRunner(BenchmarkRunner):
             self._verbose_config('max_in_memory_upload_chunks')
             self._verbose_config('max_in_memory_download_chunks')
 
-    def _verbose(self, msg):
-        if self.config.verbose:
-            print(msg)
-
     def _verbose_config(self, attr_name):
         self._verbose(
             f'  {attr_name}: {getattr(self._transfer_config, attr_name)}')

--- a/runners/s3-benchrunner-python/runner/cli.py
+++ b/runners/s3-benchrunner-python/runner/cli.py
@@ -29,9 +29,8 @@ class CliBenchmarkRunner(BenchmarkRunner):
 
         os.environ['AWS_CONFIG_FILE'] = self._cli_config_file.name
 
-        if self.config.verbose:
-            print(f'--- AWS_CONFIG_FILE ---')
-            print(config_text)
+        self._verbose(f'--- AWS_CONFIG_FILE ---')
+        self._verbose(config_text)
 
         self._cli_cmd, self._stdin_for_cli = self._derive_cli_cmd()
 


### PR DESCRIPTION
Cap the number of meta-requests we'll work on simultaneously, so the application doesn't exceed its file-descriptor limits when a workload has tons of files.

boto3 and CLI already put limits on concurrency.

We should add this limit to the other CRT runners (C and Java) someday

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
