### PR TITLE
python runners fail faster when something goes wrong

### DIFF
--- a/scripts/prep-benchmark-files.py
+++ b/scripts/prep-benchmark-files.py
@@ -413,4 +413,8 @@ if __name__ == '__main__':
                 task = future_to_task[future]
                 print(
                     f'Failure while processing "{task.key}" from: {str(task.first_benchmark_file)}')
+
+                # cancel remaining tasks
+                executor.shutdown(cancel_futures=True)
+
                 raise e


### PR DESCRIPTION
**Issue:**
If a benchmark has lots of tasks, and 1 failed, it could still take a long time for the benchmark to exit.

**Description of changes:**
For the python runners, don't start new tasks if one has failed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
