### PR TITLE
mvn clean package

### DIFF
--- a/runners/s3-benchrunner-crt-java/scripts/build.py
+++ b/runners/s3-benchrunner-crt-java/scripts/build.py
@@ -37,7 +37,7 @@ def build_aws_crt_java(work_dir: Path, branch: str):
     # for faster C compilation
     os.environ['CMAKE_BUILD_PARALLEL_LEVEL'] = str(os.cpu_count())
 
-    run(['mvn', 'install', '-Dmaven.test.skip'])
+    run(['mvn', 'clean', 'install', '-Dmaven.test.skip'])
 
 
 def build_runner() -> Path:
@@ -48,6 +48,7 @@ def build_runner() -> Path:
     runner_src = Path(__file__).parent.parent
     os.chdir(str(runner_src))
     run(['mvn',
+         'clean',
          # package along with dependencies in executable uber-java
          'package',
          # use locally installed version of aws-crt-java


### PR DESCRIPTION
*Issue #, if available:*
- If I ran `python3 scripts/build.py --branch xx --build-dir build` twice, the benchmark jar was not updated, even thought the crt jar updated.

*Description of changes:*
- Use `mvn clean package` to make sure we got the version we expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
