### PR TITLE
CDK stack actually running benchmarks!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1100,5 +1100,8 @@ package-lock.json
 .cdk.staging
 cdk.out
 
-# ignore personal CDK settings files
+# don't commit CDK context file, we want this stack to be deployable to any account
+cdk/cdk.context.json
+# don't commit personal CDK settings files
 cdk/*.settings.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -1099,3 +1099,6 @@ dependency-reduced-pom.xml
 package-lock.json
 .cdk.staging
 cdk.out
+
+# ignore personal CDK settings files
+cdk/*.settings.json

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -18,9 +18,22 @@ CDK Python project that sets up infrastructure to automatically run the S3 bench
 
 1) `cd` into this `cdk/` directory.
 
-1) Deploy this CDK app:
+1) Create a settings file for the account you'll be deploying to. Name it something like "myname.settings.json". It should look like:
+    ```json
+    {
+        "account": "012345678901",
+        "region": "us-west-2",
+        "bucket": "my-benchmarking-bucket"
+    }
+    ```
+    Fields are:
+    * `account`: AWS account ID
+    * `region`: AWS region
+    * `bucket`: (Optional) If you want to use a pre-existing bucket, or you want the bucket to persist when stack is destroyed, pass its name here. If you omit this field, or set the value `""` or `null`, a bucket will be created that gets destroyed when the stack is destroyed.
+
+1) Deploy this CDK app, passing in your settings file:
     ```sh
-    cdk deploy
+    cdk deploy -c settings=<myname.settings.json>
     ```
 
 ## Architecture
@@ -55,6 +68,8 @@ Possible Alternatives:
 ### Per-Instance Job
 
 This is what we call a Batch job that uses a specific EC2 instance type, builds [runners](../runners/#readme), and benchmarks all desired [workloads](../workloads/#readme), using all desired S3 clients.
+
+This job runs [per-instance-job.py](per-instance-job.py), which git clones the `aws-crt-s3-benchmarks` repo, then runs the [prep-build-run-benchmarks.py](../scripts/prep-build-run-benchmarks.py) script within that repo, which handles the rest. The reason that the per-instance-job clones the repo at runtime, instead of embedding at CDK deploy time, is to let us test different branches of `aws-crt-s3-benchmarks` without redeploying the CDK stack.
 
 ### Orchestrator
 

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,12 +1,42 @@
 #!/usr/bin/env python3
-import os
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Optional
 
 import aws_cdk as cdk
 
 from s3_benchmarks.s3_benchmarks_stack import S3BenchmarksStack
 
 
+@dataclass
+class Settings:
+    account: str
+    region: str
+    bucket: Optional[str]
+
+
+def load_settings(app: cdk.App) -> Settings:
+    settings_name = app.node.try_get_context("settings")
+    if settings_name is None:
+        exit('S3BenchmarksStack requires you to pick settings. ' +
+             'Pass -c settings=<name> for <name>.settings.json')
+
+    settings_path = Path(__file__).parent/f"{settings_name}.settings.json"
+    with open(settings_path) as f:
+        settings_json = json.load(f)
+
+    settings = Settings(**settings_json)
+    return settings
+
+
 app = cdk.App()
-S3BenchmarksStack(app, "S3BenchmarksStack",
-                  description="Stack for running S3 benchmarks on specific EC2 instance types")
+settings = load_settings(app)
+S3BenchmarksStack(
+    app, "S3BenchmarksStack",
+    description="Stack for running S3 benchmarks on specific EC2 instance types",
+    env=cdk.Environment(
+        account=settings.account, region=settings.region),
+    bucket=settings.bucket,
+)
 app.synth()

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -37,6 +37,6 @@ S3BenchmarksStack(
     description="Stack for running S3 benchmarks on specific EC2 instance types",
     env=cdk.Environment(
         account=settings.account, region=settings.region),
-    bucket=settings.bucket,
+    existing_bucket_name=settings.bucket,
 )
 app.synth()

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -17,12 +17,11 @@ class Settings:
 
 
 def load_settings(app: cdk.App) -> Settings:
-    settings_name = app.node.try_get_context("settings")
-    if settings_name is None:
-        exit('S3BenchmarksStack requires you to pick settings. ' +
-             'Pass -c settings=<name> for <name>.settings.json')
+    settings_path = app.node.try_get_context("settings")
+    if settings_path is None:
+        exit('S3BenchmarksStack requires you to to pass settings ' +
+             'via: -c settings=<path>. See README.md for more details.')
 
-    settings_path = Path(__file__).parent/f"{settings_name}.settings.json"
     with open(settings_path) as f:
         settings_json = json.load(f)
 

--- a/cdk/per-instance-job.py
+++ b/cdk/per-instance-job.py
@@ -79,9 +79,10 @@ if __name__ == '__main__':
     benchmarks_dir = Path('aws-crt-s3-benchmarks')
 
     # if branch specified, try to check it out
-    if args.branch:
+    preferred_branch = args.branch if args.branch != 'main' else None
+    if preferred_branch:
         os.chdir(benchmarks_dir)
-        run(['git', 'checkout', args.branch], check=False)
+        run(['git', 'checkout', preferred_branch], check=False)
         os.chdir(tmp_dir)
 
     # install tools
@@ -106,9 +107,8 @@ if __name__ == '__main__':
     cmd_args.extend(['--region', args.region])
     cmd_args.extend(['--throughput', str(instance_type.bandwidth_Gbps)])
 
-    if args.branch != 'main':
-        # don't pass along --branch if it's the default "main" value
-        cmd_args.extend(['--branch', args.branch])
+    if preferred_branch:
+        cmd_args.extend(['--branch', preferred_branch])
 
     build_dir = tmp_dir/'build'
     build_dir.mkdir()

--- a/cdk/per-instance-job.py
+++ b/cdk/per-instance-job.py
@@ -56,7 +56,7 @@ PARSER.add_argument(
 
 
 def run(cmd_args: list[str], check=True):
-    print(f'> {subprocess.list2cmdline(cmd_args)}', flush=True)
+    print(f'{Path.cwd()}> {subprocess.list2cmdline(cmd_args)}', flush=True)
     subprocess.run(cmd_args, check=check)
 
 
@@ -81,7 +81,7 @@ if __name__ == '__main__':
     # if branch specified, try to check it out
     if args.branch:
         os.chdir(benchmarks_dir)
-        run(['git', 'checkout', args.branch])
+        run(['git', 'checkout', args.branch], check=False)
         os.chdir(tmp_dir)
 
     # install tools
@@ -99,10 +99,7 @@ if __name__ == '__main__':
         workload_path = benchmarks_dir/f'workloads/{workload_name}.run.json'
         workloads.append(str(workload_path))
 
-    #
-    # Run script in aws-crt-s3-benchmarks that does the rest...
-    #
-
+    # run script in aws-crt-s3-benchmarks that does the rest
     cmd_args = [sys.executable,
                 str(benchmarks_dir/'scripts/prep-build-run-benchmarks.py')]
     cmd_args.extend(['--bucket', args.bucket])
@@ -124,7 +121,6 @@ if __name__ == '__main__':
     cmd_args.extend(['--s3-clients', *args.s3_clients])
     cmd_args.extend(['--workloads', *workloads])
 
-    # TODO: actually run this script
-    print(f'> {subprocess.list2cmdline(cmd_args)}', flush=True)
+    run(cmd_args)
 
     print("PER-INSTANCE JOB DONE!")

--- a/cdk/s3_benchmarks/s3_benchmarks_stack.py
+++ b/cdk/s3_benchmarks/s3_benchmarks_stack.py
@@ -11,6 +11,7 @@ from aws_cdk import (
 from constructs import Construct
 from math import floor
 import subprocess
+from typing import Optional
 
 import s3_benchmarks
 
@@ -36,8 +37,13 @@ DEFAULT_WORKLOADS = [
 
 class S3BenchmarksStack(Stack):
 
-    def __init__(self, scope: Construct, construct_id: str, **kwargs):
+    def __init__(self, scope: Construct, construct_id: str, bucket: Optional[str], **kwargs):
         super().__init__(scope, construct_id, **kwargs)
+
+        # TODO: create bucket if one isn't passed in
+        if not bucket:
+            raise ValueError("bucket is required")
+        self.bucket = bucket
 
         self.vpc = ec2.Vpc(self, "Vpc")
 
@@ -98,7 +104,7 @@ class S3BenchmarksStack(Stack):
                 cdk.Size.gibibytes(instance_type.mem_GiB)),
             command=[
                 "python3", "/per-instance-job.py",
-                "--bucket", "TODO-pass-this-in",
+                "--bucket", self.bucket,
                 "--region", self.region,
                 "--branch", "Ref::branch",
                 "--instance-type", instance_type.id,

--- a/cdk/s3_benchmarks/s3_benchmarks_stack.py
+++ b/cdk/s3_benchmarks/s3_benchmarks_stack.py
@@ -92,6 +92,13 @@ class S3BenchmarksStack(Stack):
                 max_session_duration=cdk.Duration.hours(
                     s3_benchmarks.PER_INSTANCE_JOB_TIMEOUT_HOURS),
             )
+            # per-instance-job can do whatever it wants to the bucket
+            self.per_instance_job_role.add_to_policy(iam.PolicyStatement(
+                actions=["s3:*"],
+                resources=[f"arn:{self.partition}:s3:::{self.bucket}",
+                           f"arn:{self.partition}:s3:::{self.bucket}/*"],
+                effect=iam.Effect.ALLOW,
+            ))
 
         container_defn = batch.EcsEc2ContainerDefinition(
             self, f"PerInstanceContainerDefn-{id_with_hyphens}",

--- a/scripts/prep-s3-files.py
+++ b/scripts/prep-s3-files.py
@@ -139,21 +139,21 @@ def prep_bucket(s3, bucket: str, region: str):
     try:
         s3.head_bucket(Bucket=bucket)
         _print_status('✓ bucket already exists')
-        return
 
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] != '404':
             raise e
 
-    _print_status('creating bucket...')
+        _print_status('creating bucket...')
 
-    s3.create_bucket(
-        Bucket=bucket,
-        CreateBucketConfiguration={'LocationConstraint': region})
+        s3.create_bucket(
+            Bucket=bucket,
+            CreateBucketConfiguration={'LocationConstraint': region})
 
-    # note: no versioning on this bucket, so we don't waste money
+        # note: no versioning on this bucket, so we don't waste money
 
-    # set lifecycles on bucket, so we don't waste money
+    # Set lifecycle rules on this bucket, so we don't waste money.
+    # Do this every time, in case the bucket was made by hand, or made by the CDK stack.
     s3.put_bucket_lifecycle_configuration(
         Bucket=bucket,
         LifecycleConfiguration={


### PR DESCRIPTION
- CDK stack completely works! The Batch jobs actually run the benchmarks!
- Introduce `my.settings.json` file to use when running CDK. This avoids accidentally deploying/destroying with the wrong account.
- Use pre-existing S3 bucket, or the S3 stack will create one and own it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
