### PR TITLE
CDK: Script to check service quotas

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -18,6 +18,12 @@ CDK Python project that sets up infrastructure to automatically run the S3 bench
 
 1) `cd` into this `cdk/` directory.
 
+1) Check that your service quotas are high enough by running:
+    ```sh
+    ./check-service-quotas.py --region REGION
+    ```
+    These service quotas refer to the max running vCPU count, for categories of EC2 instance types, allowed for your account. If the script tells you to increase a quota, you probably should, unless you're certain you don't want to run benchmarks on instance types like that.
+
 1) Create a settings file for the account you'll be deploying to. Name it something like "myname.settings.json". It should look like:
     ```json
     {
@@ -35,6 +41,15 @@ CDK Python project that sets up infrastructure to automatically run the S3 bench
     ```sh
     cdk deploy -c settings=<myname.settings.json>
     ```
+
+## Troubleshooting
+
+If your Batch job is stuck in the RUNNABLE state forever, use the
+[AWSSupport-TroubleshootAWSBatchJob](https://console.aws.amazon.com/systems-manager/documents/AWSSupport-TroubleshootAWSBatchJob/description) to find out why. Some reasons we've encountered...
+* The Batch Compute Environment was created with 1 vCPU (it must be a multiple of the vCPU an Instance Type natively has)
+* The Batch Job was created with memory equal to what the Instance Type natively has (not all that memory is available to container jobs).
+* Insufficient service quotas for EC2 types (see `check-service-quotas.py`)
+* EC2 instance type unavailable (for rare EC2 types)
 
 ## Architecture
 

--- a/cdk/check-service-quotas.py
+++ b/cdk/check-service-quotas.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import argparse
+import boto3  # type: ignore
+
+import s3_benchmarks
+
+PARSER = argparse.ArgumentParser(
+    description="Check AWS Service Quotas needed for this CDK app")
+PARSER.add_argument("--region", required=True,
+                    help="AWS region (e.g. us-west-2)")
+
+args = PARSER.parse_args()
+
+# Find min quotas needed to run each instance type one at a time.
+# (quota value is number of running vCPUs)
+quotas_needed: dict[str, int] = {}
+for instance_type in s3_benchmarks.ALL_INSTANCE_TYPES:
+    code = instance_type.quota_code
+    prev_needed = quotas_needed.get(code, 0)
+    quotas_needed[code] = max(instance_type.vcpu, prev_needed)
+
+# The orchestrator is running at the same time, so add that in too.
+orchestrator = s3_benchmarks.ORCHESTRATOR_INSTANCE_TYPE
+quotas_needed[orchestrator.quota_code] += orchestrator.vcpu
+
+# Check our current quota values
+client = boto3.client('service-quotas', region_name=args.region)
+exit_code = 0
+for quota_code, value_needed in quotas_needed.items():
+    response = client.get_service_quota(
+        ServiceCode='ec2', QuotaCode=quota_code)
+    quota = response['Quota']
+    name = quota['QuotaName']
+    current_value = quota['Value']
+    msg = f"ec2: {name}. currently:{current_value} min-required:{value_needed}"
+    if current_value < value_needed:
+        print(f"❌ {msg}")
+        console_url = f"https://{args.region}.console.aws.amazon.com/servicequotas/home/services/ec2/quotas/{quota_code}?region={args.region}"
+        print(f"  👉 Request increase here: {console_url}")
+        exit_code = 1
+    else:
+        print(f"✅ {msg}")
+exit(exit_code)

--- a/cdk/check-service-quotas.py
+++ b/cdk/check-service-quotas.py
@@ -11,7 +11,7 @@ PARSER.add_argument("--region", required=True,
 
 args = PARSER.parse_args()
 
-# Find min quotas needed to run each instance type one at a time.
+# Find quotas needed to run each instance type one at a time.
 # (quota value is number of running vCPUs)
 quotas_needed: dict[str, int] = {}
 for instance_type in s3_benchmarks.ALL_INSTANCE_TYPES:

--- a/cdk/s3_benchmarks/__init__.py
+++ b/cdk/s3_benchmarks/__init__.py
@@ -29,9 +29,9 @@ ALL_INSTANCE_TYPES = [
 ]
 
 # Orchestrator instance type
-# How we chose c6g.medium:
-# - 2nd cheapest type supported by AWS Batch ($0.034/hr as of Dec 2023 in us-west-2)
-# - a1.medium is cheaper ($0.0255/hr), but Amazon Linux 2023 doesn't support 1st gen Gravitons
+# How we chose c6g.medium (in Dec 2023, in us-west-2) (All of this likely different in the future):
+# - 2nd cheapest type ($0.034/hr) supported by AWS Batch
+# - a1.medium is cheaper ($0.0255/hr) but Amazon Linux 2023 doesn't support 1st gen Gravitons
 # - just FYI, EC2 has cheaper types (t4g.nano for $0.0042/hr) that Batch doesn't support
 ORCHESTRATOR_INSTANCE_TYPE = InstanceType(
     "c6g.medium", vcpu=1, mem_GiB=2,

--- a/cdk/s3_benchmarks/__init__.py
+++ b/cdk/s3_benchmarks/__init__.py
@@ -13,14 +13,29 @@ class InstanceType:
     vcpu: int
     mem_GiB: float
     bandwidth_Gbps: float
+    quota_code: str
 
     def resource_name(self):
         return f"S3Benchmarks-PerInstance-{self.id.replace('.', '-')}"
 
 
+# EC2 Quota: Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances
+QUOTA_CODE_STANDARD_INSTANCES = "L-1216C47A"
+
+# Instance types to run benchmarks on
 ALL_INSTANCE_TYPES = [
-    InstanceType("c5n.18xlarge", vcpu=72, mem_GiB=192, bandwidth_Gbps=100),
+    InstanceType("c5n.18xlarge", vcpu=72, mem_GiB=192,
+                 bandwidth_Gbps=100, quota_code=QUOTA_CODE_STANDARD_INSTANCES),
 ]
+
+# Orchestrator instance type
+# How we chose c6g.medium:
+# - 2nd cheapest type supported by AWS Batch ($0.034/hr as of Dec 2023 in us-west-2)
+# - a1.medium is cheaper ($0.0255/hr), but Amazon Linux 2023 doesn't support 1st gen Gravitons
+# - just FYI, EC2 has cheaper types (t4g.nano for $0.0042/hr) that Batch doesn't support
+ORCHESTRATOR_INSTANCE_TYPE = InstanceType(
+    "c6g.medium", vcpu=1, mem_GiB=2,
+    bandwidth_Gbps=10, quota_code=QUOTA_CODE_STANDARD_INSTANCES)
 
 # Timeout for job running on our slowest EC2 instance type,
 # running ALL benchmarking workloads, using ALL S3 clients.


### PR DESCRIPTION
I was experimenting with a new instance type (p4d.24xlarge) and wasted a few hours waiting for it to run, only to learn it never would until I raised my service quotas.

**Description of changes:**
* Add script to check your service quotas, and document its use
* Document the ever-useful `AWSSupport-TroubleshootAWSBatchJob` runbook that has helped me so many times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
