### PR TITLE
CDK: Use S3 Gateway Endpoint to save $$$

### DIFF
--- a/cdk/s3_benchmarks/s3_benchmarks_stack.py
+++ b/cdk/s3_benchmarks/s3_benchmarks_stack.py
@@ -57,7 +57,14 @@ class S3BenchmarksStack(Stack):
             # note: lifecycle rules for this bucket will be set later,
             # by prep-s3-files.py, which runs as part of the per-instance job
 
-        self.vpc = ec2.Vpc(self, "Vpc")
+        self.vpc = ec2.Vpc(
+            self, "Vpc",
+            # Add gateway endpoint for S3.
+            # Otherwise, it costs thousands of dollars to naively send terabytes
+            # of S3 traffic through the default NAT gateway (ask me how I know).
+            gateway_endpoints={"S3": ec2.GatewayVpcEndpointOptions(
+                service=ec2.GatewayVpcEndpointAwsService.S3)},
+        )
 
         self._define_all_per_instance_batch_jobs()
 


### PR DESCRIPTION
**Issue:** I accidentally spent $$$ last Friday running the benchmarks. AWS sent an email that evening, alerting me of the unexpected costs.

**Diagnosis:**
Digging into AWS Billing, it's almost all going to "$0.045 per GB Data Processed by NAT Gateways". Apparently, naively using a VPC to send many terabytes of data to S3, means you're paying for the NAT gateway per GB. I found this [How to reduce "Data Processed by NAT Gateways" charges?](https://repost.aws/questions/QUGTIYHNW1QoGlLz8pMvABEg/how-to-reduce-data-processed-by-nat-gateways-charges) post and followed the directions.

The post describes viewing "BytesInFromSource" and "BytesInFromDestination" in CloudWatch Metrics. I confirmed giant spikes corresponding with my benchmark runs

**Description of changes:**
Add S3 gateway endpoint to the VPC, avoiding paying huge costs to send terabytes of data through the default NAT gateway.

**Confirmation of fix:**
After deploying changes, I re-ran some of the same benchmarks (uploading and downloading hundreds of GiB). I did not see a corresponding spike in the CloudWatch metrics. They capped at 35M, instead of 10G like before. (the 35M is probably installing software and pulling github repos, and costs less than 1c)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
