### PR TITLE
Fix `boto3-crt` and `cli-crt`

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,5 @@
 boto3
+awscrt # for linting s3-benchrunner-python
 autopep8 # for code formatting
 mypy # for type checking
 aws-cdk-lib==2.116.1  # CDK

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -197,4 +197,12 @@ def build_runner(lang: str, build_root_dir: Path, branch: Optional[str]) -> list
         'java': _build_java,
     }
     build_fn = build_functions[lang]
-    return build_fn(work_dir, branch)
+
+    # restore cwd after building
+    cwd_prev = Path.cwd()
+
+    runner_cmd = build_fn(work_dir, branch)
+
+    os.chdir(cwd_prev)
+
+    return runner_cmd


### PR DESCRIPTION
Fix a few issues:
1) `cli-crt` was failing to run in CDK/Canary, because it was never installed to the system, it was only "pip installed". Fix is to run it via `python -m awscli` when possible
2) `boto3-crt` wasn't actually using CRT under the hood. Now it is.
3) (utterly trivial) build script puts `cwd` back the way it was

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
