### PR TITLE
Fix python build script

### DIFF
--- a/runners/s3-benchrunner-python/README.md
+++ b/runners/s3-benchrunner-python/README.md
@@ -83,6 +83,7 @@ First, create a virtual environment, to isolate your dev versions from system de
 ```sh
 python3 -m venv .venv
 source .venv/bin/activate
+(.venv) pip install --upgrade pip wheel
 ```
 
 Now make a build dir somewhere.

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -105,7 +105,8 @@ def _build_python(work_dir: Path, branch: Optional[str]) -> list[str]:
         run([sys.executable, '-m', 'venv', str(venv_dir)])
 
         # upgrade pip to avoid warnings
-        run([venv_python, '-m', 'pip', 'install', '--upgrade', 'pip'])
+        # and install wheel so we can build aws-crt-python
+        run([venv_python, '-m', 'pip', 'install', '--upgrade', 'pip', 'wheel'])
 
     _fetch_and_install_python_repo(
         url='https://github.com/aws/aws-cli.git',


### PR DESCRIPTION
For whatever reason, in the last week aws-crt-python started failing its build unless `wheel` is installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
