### PR TITLE
CDK: Run canary on weekends too

### DIFF
--- a/cdk/s3_benchmarks/s3_benchmarks_stack.py
+++ b/cdk/s3_benchmarks/s3_benchmarks_stack.py
@@ -400,10 +400,10 @@ class S3BenchmarksStack(Stack):
         """
         events.Rule(
             self, "CanaryCronRule",
-            # run the night before each workday
+            # run nightly
             # Note this is UTC so hour=8 means midnight PST
             schedule=events.Schedule.cron(
-                minute='0', hour='8', week_day='MON-FRI'),
+                minute='0', hour='8'),
             targets=[events_targets.BatchJob(
                 job_queue_arn=self.orchestrator_job_queue.job_queue_arn,
                 job_queue_scope=self.orchestrator_job_queue,


### PR DESCRIPTION
Previously, it only ran on weekdays to save money, since code is unlikely to change on the weekend. But it's annoying to view graphs with gaps in the data. And this will certainly make it simpler to set alarms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
