### PR TITLE
Benchmarks can run on S3 Express

### DIFF
--- a/runners/s3-benchrunner-c/benchrunner.cpp
+++ b/runners/s3-benchrunner-c/benchrunner.cpp
@@ -418,9 +418,13 @@ Task::Task(Benchmark &benchmark, size_t taskI)
 
     aws_s3_meta_request_options options;
     AWS_ZERO_STRUCT(options);
-    options.object_size_hint = &config.size;
     options.user_data = this;
     options.finish_callback = Task::onFinished;
+
+    // TODO: add "sizeHint" to config, if true then set options.object_size_hint.
+    // A transfer-manager downloading a directory would know the object size ahead of time.
+    // Size hint could have a big performance impact when downloading lots of
+    // small files and validating checksums.
 
     auto request = aws_http_message_new_request(benchmark.alloc);
     options.message = request;

--- a/runners/s3-benchrunner-c/benchrunner.cpp
+++ b/runners/s3-benchrunner-c/benchrunner.cpp
@@ -572,17 +572,22 @@ void printValueStats(const char *label, vector<double> values)
         }
     }
 
-    double variance = std::accumulate(
-        values.begin(),
-        values.end(),
-        0.0,
-        [&mean, &n](double accumulator, const double &val)
-        { return accumulator + ((val - mean) * (val - mean) / n); });
+    double variance =
+        std::accumulate(values.begin(), values.end(), 0.0, [&mean, &n](double accumulator, const double &val) {
+            return accumulator + ((val - mean) * (val - mean) / n);
+        });
 
     double stdDev = std::sqrt(variance);
 
-    printf("Overall %s Median:%f Mean:%f Min:%f Max:%f Variance:%f StdDev:%f\n",
-        label, median, mean, min, max, variance, stdDev);
+    printf(
+        "Overall %s Median:%f Mean:%f Min:%f Max:%f Variance:%f StdDev:%f\n",
+        label,
+        median,
+        mean,
+        min,
+        max,
+        variance,
+        stdDev);
 }
 
 void printStats(uint64_t bytesPerRun, const vector<double> &durations)

--- a/runners/s3-benchrunner-c/benchrunner.cpp
+++ b/runners/s3-benchrunner-c/benchrunner.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <aws/auth/credentials.h>
+#include <aws/common/string.h>
 #include <aws/common/system_resource_util.h>
 #include <aws/http/connection.h>
 #include <aws/http/request_response.h>
@@ -155,6 +156,7 @@ class Task
 // A runnable benchmark
 class Benchmark
 {
+  public:
     BenchmarkConfig config;
     string bucket;
     string region;
@@ -172,6 +174,9 @@ class Benchmark
 
     // if uploading, and filesOnDisk is false, then upload this
     vector<uint8_t> randomDataForUpload;
+
+    // derived from bucket and region (e.g. mybucket.s3.us-west-2.amazonaws.com)
+    string endpoint;
 
   public:
     // Instantiates S3 Client, does not run the benchmark yet
@@ -247,6 +252,31 @@ Benchmark::Benchmark(const BenchmarkConfig &config, string_view bucket, string_v
     this->bucket = bucket;
     this->region = region;
 
+    bool isS3Express = bucket.ends_with("--x-s3");
+    if (isS3Express)
+    {
+        // extract the "usw2-az3" from "mybucket--usw2-az3--x-s3"
+        string_view substrNoSuffix = bucket.substr(0, bucket.rfind("--"));
+        string_view azID = substrNoSuffix.substr(substrNoSuffix.rfind("--") + 2);
+
+        // Endpoint looks like: mybucket--usw2-az3--x-s3.s3express-usw2-az3.us-west-2.amazonaws.com
+        this->endpoint = bucket;
+        this->endpoint += ".s3express-";
+        this->endpoint += azID;
+        this->endpoint += ".";
+        this->endpoint += region;
+        this->endpoint += ".amazonaws.com";
+    }
+    else
+    {
+        // vanilla S3.
+        // Endpoint looks like: mybucket.s3.us-west-2.amazonaws.com
+        this->endpoint = bucket;
+        this->endpoint += ".s3.";
+        this->endpoint += region;
+        this->endpoint += ".amazonaws.com";
+    }
+
     alloc = aws_default_allocator();
 
     aws_s3_library_init(alloc);
@@ -258,8 +288,7 @@ Benchmark::Benchmark(const BenchmarkConfig &config, string_view bucket, string_v
     AWS_FATAL_ASSERT(aws_logger_init_standard(&logger, alloc, &logOpts) == 0);
     aws_logger_set(&logger);
 
-    eventLoopGroup = aws_event_loop_group_new_default_pinned_to_cpu_group(
-        alloc, 0 /*max-threads*/, 0 /*cpu-group*/, NULL /*shutdown-options*/);
+    eventLoopGroup = aws_event_loop_group_new_default(alloc, 0 /*max-threads*/, NULL /*shutdown-options*/);
     AWS_FATAL_ASSERT(eventLoopGroup != NULL);
 
     aws_host_resolver_default_options resolverOpts;
@@ -302,6 +331,12 @@ Benchmark::Benchmark(const BenchmarkConfig &config, string_view bucket, string_v
     s3ClientConfig.signing_config = &signingConfig;
     s3ClientConfig.part_size = bytesFromMiB(8);
     s3ClientConfig.throughput_target_gbps = targetThroughputGbps;
+
+    if (isS3Express)
+    {
+        signingConfig.algorithm = AWS_SIGNING_ALGORITHM_V4_S3EXPRESS;
+        s3ClientConfig.enable_s3express = true;
+    }
 
     // If writing data to disk, enable backpressure.
     // This prevents us from running out of memory due to downloading
@@ -384,12 +419,13 @@ Task::Task(Benchmark &benchmark, size_t taskI)
 
     aws_s3_meta_request_options options;
     AWS_ZERO_STRUCT(options);
+    options.object_size_hint = &config.size;
     options.user_data = this;
     options.finish_callback = Task::onFinished;
 
     auto request = aws_http_message_new_request(benchmark.alloc);
     options.message = request;
-    addHeader(request, "Host", benchmark.bucket + ".s3." + benchmark.region + ".amazonaws.com");
+    addHeader(request, "Host", benchmark.endpoint);
     aws_http_message_set_request_path(request, toCursor(string("/") + config.key));
 
     aws_input_stream *inMemoryStreamForUpload = NULL;
@@ -509,32 +545,60 @@ int Task::onDownloadData(
     return AWS_OP_SUCCESS;
 }
 
+// Print all kinds of stats about these values (median, mean, min, max, etc)
+void printValueStats(const char *label, vector<double> values)
+{
+    std::sort(values.begin(), values.end());
+    double n = values.size();
+    double min = values.front();
+    double max = values.back();
+    double mean = std::accumulate(values.begin(), values.end(), 0.0) / n;
+
+    double median = values.front();
+    if (values.size() > 1)
+    {
+        size_t middle = values.size() / 2;
+        if (values.size() % 2 == 1)
+        {
+            // odd number, use middle value
+            median = values[middle];
+        }
+        else
+        {
+            // even number, use avg of two middle values
+            double a = values[middle - 1];
+            double b = values[middle];
+            median = (a + b) / 2;
+        }
+    }
+
+    double variance = std::accumulate(
+        values.begin(),
+        values.end(),
+        0.0,
+        [&mean, &n](double accumulator, const double &val)
+        { return accumulator + ((val - mean) * (val - mean) / n); });
+
+    double stdDev = std::sqrt(variance);
+
+    printf("Overall %s Median:%f Mean:%f Min:%f Max:%f Variance:%f StdDev:%f\n",
+        label, median, mean, min, max, variance, stdDev);
+}
+
 void printStats(uint64_t bytesPerRun, const vector<double> &durations)
 {
-    double n = durations.size();
-    double durationMean = std::accumulate(durations.begin(), durations.end(), 0.0) / n;
+    vector<double> throughputsGbps;
+    for (double duration : durations)
+        throughputsGbps.push_back(bytesToGigabit(bytesPerRun) / duration);
 
-    double durationVariance = std::accumulate(
-        durations.begin(),
-        durations.end(),
-        0.0,
-        [&durationMean, &n](double accumulator, const double &val)
-        { return accumulator + ((val - durationMean) * (val - durationMean) / n); });
+    printValueStats("Throughput (Gb/s)", throughputsGbps);
 
-    double mbsMean = bytesToMegabit(bytesPerRun) / durationMean;
-    double mbsVariance = bytesToMegabit(bytesPerRun) / durationVariance;
+    printValueStats("Duration (Secs)", durations);
 
     struct aws_memory_usage_stats mu;
     aws_init_memory_usage_for_current_process(&mu);
 
-    printf(
-        "Overall stats; Throughput Mean:%.1f Mb/s Throughput Variance:%.1f Mb/s Duration Mean:%.3f s Duration "
-        "Variance:%.3f s Peak RSS:%.3f Mb\n",
-        mbsMean,
-        mbsVariance,
-        durationMean,
-        durationVariance,
-        (double)mu.maxrss / 1024.0);
+    printf("Peak RSS:%f MiB\n", (double)mu.maxrss / 1024.0);
 }
 
 int main(int argc, char *argv[])
@@ -566,14 +630,7 @@ int main(int argc, char *argv[])
         double runSecs = runDurationSecs.count();
         durations.push_back(runSecs);
         fflush(stderr);
-        printf(
-            "Run:%d Secs:%.3f Gb/s:%.1f Mb/s:%.1f GiB/s:%.1f MiB/s:%.1f\n",
-            runI + 1,
-            runSecs,
-            bytesToGigabit(bytesPerRun) / runSecs,
-            bytesToMegabit(bytesPerRun) / runSecs,
-            bytesToGiB(bytesPerRun) / runSecs,
-            bytesToMiB(bytesPerRun) / runSecs);
+        printf("Run:%d Secs:%f Gb/s:%f\n", runI + 1, runSecs, bytesToGigabit(bytesPerRun) / runSecs);
         fflush(stdout);
 
         // break out if we've exceeded maxRepeatSecs

--- a/runners/s3-benchrunner-c/benchrunner.cpp
+++ b/runners/s3-benchrunner-c/benchrunner.cpp
@@ -572,10 +572,10 @@ void printValueStats(const char *label, vector<double> values)
         }
     }
 
-    double variance =
-        std::accumulate(values.begin(), values.end(), 0.0, [&mean, &n](double accumulator, const double &val) {
-            return accumulator + ((val - mean) * (val - mean) / n);
-        });
+    auto varianceAccumulatorOp = [mean, n](double accumulator, const double &val)
+    { return accumulator + ((val - mean) * (val - mean) / n); };
+
+    double variance = std::accumulate(values.begin(), values.end(), 0.0, varianceAccumulatorOp);
 
     double stdDev = std::sqrt(variance);
 

--- a/runners/s3-benchrunner-c/benchrunner.cpp
+++ b/runners/s3-benchrunner-c/benchrunner.cpp
@@ -269,8 +269,7 @@ Benchmark::Benchmark(const BenchmarkConfig &config, string_view bucket, string_v
     }
     else
     {
-        // vanilla S3.
-        // Endpoint looks like: mybucket.s3.us-west-2.amazonaws.com
+        // Standard S3 endpoint looks like: mybucket.s3.us-west-2.amazonaws.com
         this->endpoint = bucket;
         this->endpoint += ".s3.";
         this->endpoint += region;

--- a/runners/s3-benchrunner-c/benchrunner.cpp
+++ b/runners/s3-benchrunner-c/benchrunner.cpp
@@ -572,10 +572,13 @@ void printValueStats(const char *label, vector<double> values)
         }
     }
 
-    auto varianceAccumulatorOp = [mean, n](double accumulator, const double &val)
-    { return accumulator + ((val - mean) * (val - mean) / n); };
-
-    double variance = std::accumulate(values.begin(), values.end(), 0.0, varianceAccumulatorOp);
+    // clang-format off
+    double variance = std::accumulate(
+        values.begin(),
+        values.end(),
+        0.0,
+        [mean, n](double accumulator, const double &val) { return accumulator + ((val - mean) * (val - mean) / n); });
+    // clang-format on
 
     double stdDev = std::sqrt(variance);
 

--- a/runners/s3-benchrunner-java/README.md
+++ b/runners/s3-benchrunner-java/README.md
@@ -11,12 +11,11 @@ mvn package
 
 This produces the uber-jar: `target/s3-benchrunner-java-1.0-SNAPSHOT.jar` .
 
-### Using a local build of aws-crt-java
+### Using a local build of aws-crt-java and aws-sdk-java-v2
 
-By default, the latest release of aws-crt-java is pulled from Maven Central.
+By default, the latest release of aws-crt-java and aws-sdk-java-v2 are pulled from Maven Central. If you want to build these locally...
 
-If you want to build aws-crt-java locally:
-
+First, install aws-crt-java (this installs version 1.0.0-SNAPSHOT):
 ```sh
 cd my/dev/dir
 git clone https://github.com/awslabs/aws-crt-java.git
@@ -25,25 +24,19 @@ git submodule update --init
 mvn install -Dmaven.test.skip
 ```
 
-This installs version 1.0.0-SNAPSHOT.
-
-Now get the runner to use it by building with the "snapshot" profile active:
-
-```sh
-cd /path/to/s3-benchrunner-java
-mvn clean -P snapshot package
+Next, install the SDK:
 ```
-
-### Using a local build of aws-sdk-java-v2
-
-```sh
 cd my/dev/dir
 git clone https://github.com/aws/aws-sdk-java-v2.git
 cd aws-sdk-java-v2
-mvn clean install -pl :s3-transfer-manager,:s3,:bom-internal,:bom -P quick --am
+mvn clean install -pl :s3-transfer-manager,:s3,:bom-internal,:bom -P quick --am -Dawscrt.version=1.0.0-SNAPSHOT
 ```
 
-This installs the latest SNAPSHOT version. Now rebuild the runner with `mvn clean package` , it will pick up the latest SNAPSHOT version directly.
+Finally, build the runner:
+```sh
+cd /path/to/s3-benchrunner-java
+mvn clean package -Dawscrt.version=1.0.0-SNAPSHOT
+```
 
 ### Working in IntelliJ
 

--- a/runners/s3-benchrunner-java/pom.xml
+++ b/runners/s3-benchrunner-java/pom.xml
@@ -10,8 +10,8 @@
 
   <properties>
     <!-- build with -Dawscrt.version=1.0.0-SNAPSHOT to use the locally installed dev version) -->
-    <awscrt.version>[0.26,)</awscrt.version>
-    <aws.sdk.version>[2.23,)</aws.sdk.version>
+    <awscrt.version>[0.29,)</awscrt.version>
+    <aws.sdk.version>[2.25,)</aws.sdk.version>
 
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -94,6 +94,11 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.10.1</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk.crt</groupId>
+      <artifactId>aws-crt</artifactId>
+      <version>0.28.11</version>
     </dependency>
   </dependencies>
 

--- a/runners/s3-benchrunner-java/pom.xml
+++ b/runners/s3-benchrunner-java/pom.xml
@@ -17,15 +17,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <profiles>
-    <profile>
-      <id>snapshot</id>
-      <properties>
-        <awscrt.version>1.0.0-SNAPSHOT</awscrt.version>
-      </properties>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
       <plugin>
@@ -94,11 +85,6 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.10.1</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk.crt</groupId>
-      <artifactId>aws-crt</artifactId>
-      <version>0.28.11</version>
     </dependency>
   </dependencies>
 

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/Main.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/Main.java
@@ -74,13 +74,10 @@ public class Main {
             long runDurationNs = System.nanoTime() - runStartNs;
             double runSecs = Util.nanoToSecs(runDurationNs);
             durations.add(runSecs);
-            System.out.printf("Run:%d Secs:%.3f Gb/s:%.1f Mb/s:%.1f GiB/s:%.1f MiB/s:%.1f%n",
+            System.out.printf("Run:%d Secs:%f Gb/s:%f%n",
                     runI + 1,
                     runSecs,
-                    Util.bytesToGigabit(bytesPerRun) / runSecs,
-                    Util.bytesToMegabit(bytesPerRun) / runSecs,
-                    Util.bytesToGiB(bytesPerRun) / runSecs,
-                    Util.bytesToMiB(bytesPerRun) / runSecs);
+                    Util.bytesToGigabit(bytesPerRun) / runSecs);
 
             // break out if we've exceeded maxRepeatSecs
             double appDurationSecs = Util.nanoToSecs(System.nanoTime() - appStartNs);

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
@@ -36,16 +36,14 @@ public class CRTJavaBenchmarkRunner extends BenchmarkRunner {
         // S3 Express buckets look like "mybucket--usw2-az3--x-s3"
         Matcher s3ExpressMatcher = Pattern.compile("--(.*)--x-s3$").matcher(bucket);
         boolean isS3Express = s3ExpressMatcher.find();
-        if (isS3Express)
-        {
+        if (isS3Express) {
             // extract the "usw2-az3" from "mybucket--usw2-az3--x-s3"
             String azID = s3ExpressMatcher.group(1);
 
-            // Endpoint looks like: mybucket--usw2-az3--x-s3.s3express-usw2-az3.us-west-2.amazonaws.com
+            // Endpoint looks like:
+            // mybucket--usw2-az3--x-s3.s3express-usw2-az3.us-west-2.amazonaws.com
             endpoint = bucket + ".s3express-" + azID + "." + region + ".amazonaws.com";
-        }
-        else
-        {
+        } else {
             // vanilla S3.
             // Endpoint looks like: mybucket.s3.us-west-2.amazonaws.com
             endpoint = bucket + ".s3." + region + ".amazonaws.com";

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
@@ -51,7 +51,7 @@ public class CRTJavaBenchmarkRunner extends BenchmarkRunner {
             endpoint = bucket + ".s3." + region + ".amazonaws.com";
         }
 
-        eventLoopGroup = new EventLoopGroup(0, 0);
+        eventLoopGroup = new EventLoopGroup(0);
 
         hostResolver = new HostResolver(eventLoopGroup);
 

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
@@ -44,8 +44,7 @@ public class CRTJavaBenchmarkRunner extends BenchmarkRunner {
             // mybucket--usw2-az3--x-s3.s3express-usw2-az3.us-west-2.amazonaws.com
             endpoint = bucket + ".s3express-" + azID + "." + region + ".amazonaws.com";
         } else {
-            // vanilla S3.
-            // Endpoint looks like: mybucket.s3.us-west-2.amazonaws.com
+            // Standard S3 endpoint looks like: mybucket.s3.us-west-2.amazonaws.com
             endpoint = bucket + ".s3." + region + ".amazonaws.com";
         }
 

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaTask.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaTask.java
@@ -1,5 +1,7 @@
 package com.example.s3benchrunner.crtjava;
 
+import com.example.s3benchrunner.TaskConfig;
+import com.example.s3benchrunner.Util;
 import software.amazon.awssdk.crt.CRT;
 import software.amazon.awssdk.crt.http.HttpHeader;
 import software.amazon.awssdk.crt.http.HttpRequest;
@@ -17,9 +19,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-
-import com.example.s3benchrunner.TaskConfig;
-import com.example.s3benchrunner.Util;
 
 class CRTJavaTask implements S3MetaRequestResponseHandler {
 
@@ -45,7 +44,7 @@ class CRTJavaTask implements S3MetaRequestResponseHandler {
         String httpPath = "/" + config.key;
         HttpRequestBodyStream requestUploadStream = null;
         var headers = new ArrayList<HttpHeader>();
-        headers.add(new HttpHeader("Host", runner.bucket + ".s3." + runner.region + ".amazonaws.com"));
+        headers.add(new HttpHeader("Host", runner.endpoint));
 
         if (config.action.equals("upload")) {
             options.withMetaRequestType(S3MetaRequestOptions.MetaRequestType.PUT_OBJECT);

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/sdkjava/SDKJavaBenchmarkRunner.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/sdkjava/SDKJavaBenchmarkRunner.java
@@ -3,12 +3,9 @@ package com.example.s3benchrunner.sdkjava;
 import com.example.s3benchrunner.BenchmarkConfig;
 import com.example.s3benchrunner.BenchmarkRunner;
 import com.example.s3benchrunner.TaskConfig;
-import com.example.s3benchrunner.Util;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
-import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
 

--- a/runners/s3-benchrunner-python/main.py
+++ b/runners/s3-benchrunner-python/main.py
@@ -62,11 +62,8 @@ if __name__ == '__main__':
 
         run_secs = ns_to_secs(time.perf_counter_ns() - run_start_ns)
         print(f'Run:{run_i+1} ' +
-              f'Secs:{run_secs:.3f} ' +
-              f'Gb/s:{bytes_to_gigabit(bytes_per_run) / run_secs:.3f} ' +
-              f'Mb/s:{bytes_to_megabit(bytes_per_run) / run_secs:.3f} ' +
-              f'GiB/s:{bytes_to_GiB(bytes_per_run) / run_secs:.3f} ' +
-              f'MiB/s:{bytes_to_MiB(bytes_per_run) / run_secs:.3f}',
+              f'Secs:{run_secs:f} ' +
+              f'Gb/s:{bytes_to_gigabit(bytes_per_run) / run_secs:f}',
               flush=True)
 
         # Break out if we've exceeded max_repeat_secs

--- a/runners/s3-benchrunner-python/runner/boto3.py
+++ b/runners/s3-benchrunner-python/runner/boto3.py
@@ -1,7 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import sys
 
-from runner import BenchmarkConfig, BenchmarkRunner, gigabit_to_bytes
+from runner import BenchmarkConfig, BenchmarkRunner
 
 
 class Boto3BenchmarkRunner(BenchmarkRunner):

--- a/runners/s3-benchrunner-python/runner/crt.py
+++ b/runners/s3-benchrunner-python/runner/crt.py
@@ -18,12 +18,13 @@ class CrtBenchmarkRunner(BenchmarkRunner):
 
         # S3 Express buckets look like "mybucket--usw2-az3--x-s3" (where "usw2-az3" is the AZ ID)
         s3express_match = re.search("--(.*)--x-s3$", self.config.bucket)
-        is_s3express = s3express_match is not None
-        if is_s3express:
+        if s3express_match:
+            is_s3express = True
             az_id = s3express_match.group(1)
             self.endpoint = \
                 f"{self.config.bucket}.s3express-{az_id}.{self.config.region}.amazonaws.com"
         else:
+            is_s3express = False
             self.endpoint = \
                 f"{self.config.bucket}.s3.{self.config.region}.amazonaws.com"
 

--- a/runners/s3-benchrunner-python/runner/crt.py
+++ b/runners/s3-benchrunner-python/runner/crt.py
@@ -27,7 +27,7 @@ class CrtBenchmarkRunner(BenchmarkRunner):
             self.endpoint = \
                 f"{self.config.bucket}.s3.{self.config.region}.amazonaws.com"
 
-        elg = awscrt.io.EventLoopGroup(cpu_group=0)
+        elg = awscrt.io.EventLoopGroup()
         resolver = awscrt.io.DefaultHostResolver(elg)
         bootstrap = awscrt.io.ClientBootstrap(elg, resolver)
         credential_provider = awscrt.auth.AwsCredentialsProvider.new_default_chain(

--- a/scripts/prep-s3-files.py
+++ b/scripts/prep-s3-files.py
@@ -154,23 +154,25 @@ def prep_bucket(s3, bucket: str, region: str):
 
     # Set lifecycle rules on this bucket, so we don't waste money.
     # Do this every time, in case the bucket was made by hand, or made by the CDK stack.
-    # s3.put_bucket_lifecycle_configuration(
-    #     Bucket=bucket,
-    #     LifecycleConfiguration={
-    #         'Rules': [
-    #             {
-    #                 'ID': 'Abort all incomplete multipart uploads after 1 day',
-    #                 'Status': 'Enabled',
-    #                 'Filter': {'Prefix': ''},  # blank string means all
-    #                 'AbortIncompleteMultipartUpload': {'DaysAfterInitiation': 1},
-    #             },
-    #             {
-    #                 'ID': 'Objects under "upload/" expire after 1 day',
-    #                 'Status': 'Enabled',
-    #                 'Filter': {'Prefix': 'upload/'},
-    #                 'Expiration': {'Days': 1},
-    #             },
-    #         ]})
+    # NOTE: S3 Express doesn't support lifecycle rules (as of March 2024).
+    if not bucket.endswith('--x-s3'):
+        s3.put_bucket_lifecycle_configuration(
+            Bucket=bucket,
+            LifecycleConfiguration={
+                'Rules': [
+                    {
+                        'ID': 'Abort all incomplete multipart uploads after 1 day',
+                        'Status': 'Enabled',
+                        'Filter': {'Prefix': ''},  # blank string means all
+                        'AbortIncompleteMultipartUpload': {'DaysAfterInitiation': 1},
+                    },
+                    {
+                        'ID': 'Objects under "upload/" expire after 1 day',
+                        'Status': 'Enabled',
+                        'Filter': {'Prefix': 'upload/'},
+                        'Expiration': {'Days': 1},
+                    },
+                ]})
 
 
 @dataclass

--- a/scripts/prep-s3-files.py
+++ b/scripts/prep-s3-files.py
@@ -154,23 +154,23 @@ def prep_bucket(s3, bucket: str, region: str):
 
     # Set lifecycle rules on this bucket, so we don't waste money.
     # Do this every time, in case the bucket was made by hand, or made by the CDK stack.
-    s3.put_bucket_lifecycle_configuration(
-        Bucket=bucket,
-        LifecycleConfiguration={
-            'Rules': [
-                {
-                    'ID': 'Abort all incomplete multipart uploads after 1 day',
-                    'Status': 'Enabled',
-                    'Filter': {'Prefix': ''},  # blank string means all
-                    'AbortIncompleteMultipartUpload': {'DaysAfterInitiation': 1},
-                },
-                {
-                    'ID': 'Objects under "upload/" expire after 1 day',
-                    'Status': 'Enabled',
-                    'Filter': {'Prefix': 'upload/'},
-                    'Expiration': {'Days': 1},
-                },
-            ]})
+    # s3.put_bucket_lifecycle_configuration(
+    #     Bucket=bucket,
+    #     LifecycleConfiguration={
+    #         'Rules': [
+    #             {
+    #                 'ID': 'Abort all incomplete multipart uploads after 1 day',
+    #                 'Status': 'Enabled',
+    #                 'Filter': {'Prefix': ''},  # blank string means all
+    #                 'AbortIncompleteMultipartUpload': {'DaysAfterInitiation': 1},
+    #             },
+    #             {
+    #                 'ID': 'Objects under "upload/" expire after 1 day',
+    #                 'Status': 'Enabled',
+    #                 'Filter': {'Prefix': 'upload/'},
+    #                 'Expiration': {'Days': 1},
+    #             },
+    #         ]})
 
 
 @dataclass

--- a/scripts/prep-s3-files.py
+++ b/scripts/prep-s3-files.py
@@ -304,7 +304,8 @@ def prep_file_in_s3(task: Task, s3, bucket: str, existing_s3_objects: dict[str, 
         # if it's the right size etc, then we can skip the upload
         if existing.size != task.size:
             _print_status('re-uploading due to size mismatch')
-        elif existing.checksum != task.checksum:
+        elif (task.checksum is not None) and (existing.checksum != task.checksum):
+            # NOTE: S3 Express gives objects checksums even if they were uploaded without any
             _print_status('re-uploading due to checksum mismatch')
         else:
             # return early, file already exists

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -169,8 +169,12 @@ def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
                    main_branch='master',
                    preferred_branch=branch)
     os.chdir(str(sdk_src))
-    run(['mvn', 'clean', 'install', '-pl',
-         ':s3-transfer-manager,:s3,:bom-internal,:bom', '-P', 'quick', '--am'])
+    run(['mvn', 'clean', 'install',
+         '--projects', ':s3-transfer-manager,:s3,:bom-internal,:bom',
+         '--activate-profiles', 'quick',
+         '--also-make',
+         '-Dawscrt.version=1.0.0-SNAPSHOT',
+    ])
 
     # Build runner
     runner_src = RUNNERS['java'].dir
@@ -180,7 +184,7 @@ def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
          # package along with dependencies in executable uber-java
          'package',
          # use locally installed version of aws-crt-java
-         '--activate-profiles', 'snapshot',
+         '-Dawscrt.version=1.0.0-SNAPSHOT',
          ])
 
     # return command for running the jar

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -173,9 +173,9 @@ def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
          '--projects', ':s3-transfer-manager,:s3,:bom-internal,:bom',
          '--activate-profiles', 'quick',
          '--also-make',
-          # use locally installed version of aws-crt-java
+         # use locally installed version of aws-crt-java
          '-Dawscrt.version=1.0.0-SNAPSHOT',
-    ])
+         ])
 
     # Build runner
     runner_src = RUNNERS['java'].dir

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -173,6 +173,7 @@ def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
          '--projects', ':s3-transfer-manager,:s3,:bom-internal,:bom',
          '--activate-profiles', 'quick',
          '--also-make',
+          # use locally installed version of aws-crt-java
          '-Dawscrt.version=1.0.0-SNAPSHOT',
     ])
 

--- a/scripts/utils/metrics.py
+++ b/scripts/utils/metrics.py
@@ -71,23 +71,15 @@ def _given_stdout_get_list_throughput_per_run_in_gigabits(stdout: str) -> list[f
     For example, given:
     '''
     [ERROR] [2024-01-10T22:46:03Z] [00007f4124174440] [AuthCredentialsProvider] - ...
-    Run:1 Secs:8.954 Gb/s:28.8 Mb/s:28780.0 GiB/s:3.4 MiB/s:3430.8
-    Run:2 Secs:9.180 Gb/s:28.1 Mb/s:28072.4 GiB/s:3.3 MiB/s:3346.5
-    Run:3 Secs:9.321 Gb/s:27.6 Mb/s:27648.3 GiB/s:3.2 MiB/s:3295.9
+    Run:1 Secs:8.954437 Gb/s:28.847134
+    Run:2 Secs:9.180856 Gb/s:28.116831
+    Run:3 Secs:9.321967 Gb/s:27.612145
     Done!
     '''
 
-    Returns [28.780, 28.0724, 27.6483]
+    Returns [28.847134, 28.116831, 27.612145]
     """
-    # NOTE: Runners print throughput thats "nice" for humans to read,
-    # (no scientific notation and only .1f precision).
-    # They print throughput at multiple scales (Gb, Mb, GiB, MiB)
-    # so people can look eyeball whichever number makes sense to them.
-    #
-    # Anyway, parse "Mb/s" here since it will be the largest number
-    # and therefore retain the most precision. But return it as gigabits
-    # since that's how we usually think of throughput.
-    pattern = re.compile(r'^Run:\d+ .* Mb/s:([^ ]+) ')
+    pattern = re.compile(r'^Run:\d+ .* Gb/s:(\d+\.\d+)')
     throughput_per_run = []
     for line in stdout.splitlines():
         m = pattern.match(line)


### PR DESCRIPTION
**Description of Changes:**
- Benchmarks can run on S3 Express
    - regular SDKs could already handle this, but using CRT directly is more manual
- Simplify benchmark output
    - like `Run:1 Secs:8.954437 Gb/s:28.847134` instead of  ~Run:1 Secs:8.954 Gb/s:28.8 Mb/s:28780.0 GiB/s:3.4 MiB/s:3430.8~
- Fix build scripts (and README) for using locally built aws-crt-java

TODO: Update CDK so that it runs in the same Availability Zone as your S3 Express bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
