### PR TITLE
CDK: Support S3 Express

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -29,14 +29,22 @@ CDK Python project that sets up infrastructure to automatically run the S3 bench
     {
         "account": "012345678901",
         "region": "us-west-2",
-        "bucket": "my-benchmarking-bucket",
+        "buckets": ["my-benchmarking-bucket", "my-benchmarking-bucket--usw2-az3--x-s3"],
+        "availability_zone": "us-west-2a",
         "canary": false
     }
     ```
     Fields are:
     * `account`: AWS account ID
     * `region`: AWS region
-    * `bucket`: (Optional) If you want to use a pre-existing bucket, or you want the bucket to persist when stack is destroyed, pass its name here. If you omit this field, or set the value `""` or `null`, a bucket will be created that gets destroyed when the stack is destroyed.
+    * `buckets`: (Optional list) Omit this field to use a standard bucket that's destroyed when the stack is destroyed. Pass 2 names if you want to benchmark both an S3 Express One Zone directory bucket, and a standard bucket. Or just pass 1 name. If you pass names, the buckets will be created if necessary, and the buckets will persist even after the stack is destroyed.
+    * `availability_zone`: (Required for S3 Express) Name of AWS Availability Zone to run benchmarks in. **WARNING: Zone ID != Zone Name**. To find the zone *name* corresponding to the zone *ID* for your directory bucket:
+        * Get the zone ID: For bucket named "my-benchmarking-bucket--usw2-az3--x-s3", this would be: "usw2-az3".
+        * Run:
+            ```sh
+            aws ec2 describe-availability-zones --zone-ids <zone-id-from-above>
+            ```
+        * From output, get "ZoneName", and use that. It will be like "us-west-2d".
     * `canary`: (Optional) Set `true` to have the benchmarks run nightly.
 
 1) Deploy this CDK app, passing in your settings file:

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3
 from dataclasses import dataclass
 import json
-from pathlib import Path
 from typing import Optional
 
 import aws_cdk as cdk
 
 from s3_benchmarks.s3_benchmarks_stack import S3BenchmarksStack
+from s3_benchmarks import get_bucket_storage_class, is_s3express_bucket
 
 
 @dataclass
 class Settings:
     account: str
     region: str
-    bucket: Optional[str] = None
+    buckets: Optional[list[str]] = None
+    availability_zone: Optional[str] = None
     canary: bool = False
 
 
@@ -27,6 +28,22 @@ def load_settings(app: cdk.App) -> Settings:
         settings_json = json.load(f)
 
     settings = Settings(**settings_json)
+
+    if settings.buckets:
+        # Availability Zone super matters for S3 Express One Zone
+        if any([is_s3express_bucket(x) for x in settings.buckets]) and not settings.availability_zone:
+            exit("availability_zone must be specified when using " +
+                 "S3 Express One Zone directory buckets.")
+
+        # If multiple buckets, they can't be the same storage class.
+        # You wouldn't be able to tell whose metrics are whose, since
+        # we use StorageClass as a metrics dimension.
+        num_storage_classes = len({get_bucket_storage_class(x)
+                                  for x in settings.buckets})
+        if num_storage_classes != len(settings.buckets):
+            exit("Cannot benchmark multiple buckets unless they're different storage classes " +
+                 "(i.e. S3 Express, S3 Standard).")
+
     return settings
 
 
@@ -41,7 +58,8 @@ S3BenchmarksStack(
     description="Stack for running S3 benchmarks on specific EC2 instance types",
     env=cdk.Environment(
         account=settings.account, region=settings.region),
-    existing_bucket_name=settings.bucket,
+    existing_bucket_names=settings.buckets,
+    availability_zone=settings.availability_zone,
     add_canary=settings.canary,
 )
 app.synth()

--- a/cdk/orchestrator-job.py
+++ b/cdk/orchestrator-job.py
@@ -34,6 +34,9 @@ def comma_separated_list(arg):
 PARSER = argparse.ArgumentParser(
     description="Run S3 benchmarks on each EC2 instance type")
 PARSER.add_argument(
+    '--buckets', required=True, type=comma_separated_list,
+    help="S3 bucket names, comma separated (e.g. my-bucket,my-bucket--usw2-az3--x-s3)")
+PARSER.add_argument(
     '--region', required=True,
     help="AWS region (e.g. us-west-2)")
 PARSER.add_argument(
@@ -160,6 +163,7 @@ if __name__ == '__main__':
             # pass select args along to per-instance job
             'parameters': {
                 'branch': args.branch,
+                'buckets': ','.join(args.buckets),
                 'workloads': ','.join(args.workloads),
                 's3Clients': ','.join(args.s3_clients),
             },

--- a/cdk/per-instance-job.py
+++ b/cdk/per-instance-job.py
@@ -29,8 +29,8 @@ def comma_separated_list(arg):
 PARSER = argparse.ArgumentParser(
     description="Run S3 benchmarks on each EC2 instance type")
 PARSER.add_argument(
-    '--bucket', required=True,
-    help="S3 bucket name")
+    '--buckets', required=True, type=comma_separated_list,
+    help="S3 bucket names, comma separated (e.g. my-bucket,my-bucket--usw2-az3--x-s3)")
 PARSER.add_argument(
     '--region', required=True,
     help="AWS region (e.g. us-west-2)")
@@ -105,7 +105,7 @@ if __name__ == '__main__':
     # run script in aws-crt-s3-benchmarks that does the rest
     cmd_args = [sys.executable,
                 str(benchmarks_dir/'scripts/prep-build-run-benchmarks.py')]
-    cmd_args.extend(['--bucket', args.bucket])
+    cmd_args.extend(['--buckets', *args.buckets])
     cmd_args.extend(['--region', args.region])
     cmd_args.extend(['--throughput', str(instance_type.bandwidth_Gbps)])
 

--- a/cdk/s3_benchmarks/__init__.py
+++ b/cdk/s3_benchmarks/__init__.py
@@ -50,3 +50,11 @@ PER_INSTANCE_JOB_TIMEOUT_HOURS = 6.0
 # Timeout for orchestrator to run each per-instance benchmarking job,
 # one after the other.
 ORCHESTRATOR_JOB_TIMEOUT_HOURS = 12.0
+
+
+def is_s3express_bucket(bucket: str) -> bool:
+    return bucket.endswith('--x-s3')
+
+
+def get_bucket_storage_class(bucket: str) -> str:
+    return 'S3Express' if is_s3express_bucket(bucket) else 'S3Standard'

--- a/scripts/run-benchmarks.py
+++ b/scripts/run-benchmarks.py
@@ -76,6 +76,7 @@ for workload in workloads:
             run_end_time=end_time,
             s3_client_id=args.s3_client,
             workload_path=workload,
+            bucket=args.bucket,
             region=args.region,
             instance_type=args.metrics_instance_type,
             branch=args.metrics_branch,

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -160,3 +160,18 @@ def print_banner(msg, *, border=5, char='*'):
     print(top_bottom_row)
     print(middle_row)
     print(top_bottom_row)
+
+
+def is_s3express_bucket(bucket: str) -> bool:
+    return bucket.endswith('--x-s3')
+
+
+def get_s3express_bucket_az_id(bucket: str) -> str:
+    assert is_s3express_bucket(bucket)
+    # extract the "usw2-az3" from "mybucket--usw2-az3--x-s3"
+    az_id = bucket.split('--')[-2]
+    return az_id
+
+
+def get_bucket_storage_class(bucket: str) -> str:
+    return 'S3Express' if is_s3express_bucket(bucket) else 'S3Standard'

--- a/scripts/utils/metrics.py
+++ b/scripts/utils/metrics.py
@@ -1,9 +1,9 @@
 import boto3  # type: ignore
 from datetime import datetime
-import json
 from pathlib import Path
 import re
 from typing import Optional
+from utils import get_bucket_storage_class
 
 
 def report_metrics(*,
@@ -12,6 +12,7 @@ def report_metrics(*,
                    run_end_time: datetime,
                    s3_client_id: str,
                    workload_path: Path,
+                   bucket: str,
                    region: str,
                    instance_type: Optional[str],
                    branch: Optional[str],
@@ -31,6 +32,7 @@ def report_metrics(*,
         {'Name': 'InstanceType', 'Value': instance_type or 'Unknown'},
         {'Name': 'Branch', 'Value': branch or 'Unknown'},
         {'Name': 'Workload', 'Value': workload_path.name.split('.')[0]},
+        {'Name': 'StorageClass', 'Value': get_bucket_storage_class(bucket)},
     ]
 
     metric_data = []


### PR DESCRIPTION
* Fix CDK scripts to support S3 Express One Zone directory buckets
* Allow benchmark to run on multiple buckets (1 S3 Express directory bucket, 1 standard bucket) per go
    * I debated continuing with 1 bucket per CDK deployment. So you'd need 2 deployments to benchmark S3 Express & S3 Standard. But this would make any future alarms very annoying. You could end up with 2 identical alarms going off when benchmarks start failing for some random reason. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
