### PR TITLE
CDK: Use S3Express Gateway Endpoint to save $$$

### DIFF
--- a/cdk/s3_benchmarks/s3_benchmarks_stack.py
+++ b/cdk/s3_benchmarks/s3_benchmarks_stack.py
@@ -102,8 +102,16 @@ class S3BenchmarksStack(Stack):
             # Add gateway endpoint for S3.
             # Otherwise, it costs thousands of dollars to naively send terabytes
             # of S3 traffic through the default NAT gateway (ask me how I know).
-            gateway_endpoints={"S3": ec2.GatewayVpcEndpointOptions(
-                service=ec2.GatewayVpcEndpointAwsService.S3)},
+            #
+            # Also add one for S3 Express.
+            # If you naively assumed the S3 one would cover this,
+            # you'd be out thousands of dollars more (ask me how I know).
+            gateway_endpoints={
+                "S3": ec2.GatewayVpcEndpointOptions(
+                    service=ec2.GatewayVpcEndpointAwsService("s3")),
+                "S3Express": ec2.GatewayVpcEndpointOptions(
+                    service=ec2.GatewayVpcEndpointAwsService("s3express"))
+            },
             availability_zones=[availability_zone],
         )
 


### PR DESCRIPTION
Similar to https://github.com/awslabs/aws-crt-s3-benchmarks/pull/42. I continue to be surprised by the many ways the S3Express is and isn't a different service than S3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
