### PR TITLE
Use pwrite for C benchmark

### DIFF
--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <random>
 
+#include <stdio.h>
+
 #include <aws/common/system_resource_util.h>
 
 #include <nlohmann/json.hpp>
@@ -227,12 +229,13 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
         benchmark->run();
 
         duration<double> runDurationSecs = high_resolution_clock::now() - runStart;
+
         double runSecs = runDurationSecs.count();
         durations.push_back(runSecs);
         fflush(stderr);
         printf("Run:%d Secs:%f Gb/s:%f\n", runI + 1, runSecs, bytesToGigabit(bytesPerRun) / runSecs);
         fflush(stdout);
-
+        remove("download/30GiB-1x/1");
         // break out if we've exceeded maxRepeatSecs
         duration<double> appDurationSecs = high_resolution_clock::now() - appStart;
         if (appDurationSecs >= 1s * config.maxRepeatSecs)

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -235,6 +235,7 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
         fflush(stderr);
         printf("Run:%d Secs:%f Gb/s:%f\n", runI + 1, runSecs, bytesToGigabit(bytesPerRun) / runSecs);
         fflush(stdout);
+        /* TODO: properly remove the existing file */
         remove("download/30GiB-1x/1");
         // break out if we've exceeded maxRepeatSecs
         duration<double> appDurationSecs = high_resolution_clock::now() - appStart;


### PR DESCRIPTION
*Issue #, if available:*
Use pwrite to improve the disk write performance. 

With current main of aws-c-s3. For 5GiB-1x workload
- The main branch of benchmark -> 9.1Gbps
- The pwrite version -> 16.1 Gbps

*Description of changes:*

Todo:
- With pwrite, without deleting the old file and then repeat the same workload, I got a much faster performance (around 30Gbps), which I think it maybe OS finds the existing file is the same, not flushing to disk.
- only works on al2023?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
