### PR TITLE
Support Rust TransferManager Upload File

### DIFF
--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -611,12 +611,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,15 +1440,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,27 +1489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
 ]
 
 [[package]]
@@ -1696,8 +1660,8 @@ dependencies = [
  "aws-sdk-s3",
  "bytes",
  "clap",
+ "fastrand",
  "futures",
- "rand",
  "serde",
  "serde_json",
  "thiserror",
@@ -2344,7 +2308,6 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 

--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -612,6 +612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1514,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
@@ -1670,6 +1706,7 @@ dependencies = [
  "aws-sdk-s3",
  "clap",
  "futures",
+ "rand",
  "serde",
  "serde_json",
  "thiserror",
@@ -2382,6 +2419,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
 [[package]]
 name = "aws-s3-transfer-manager"
 version = "0.1.0"
-source = "git+ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git?branch=main#fc227cc4d8bfe099ee6543581862a306da143c8c"
+source = "git+ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git?rev=d085949e930b0ef99031c0fd33c24d6c68fac4dd#d085949e930b0ef99031c0fd33c24d6c68fac4dd"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -1704,6 +1704,7 @@ dependencies = [
  "aws-config",
  "aws-s3-transfer-manager",
  "aws-sdk-s3",
+ "bytes",
  "clap",
  "futures",
  "rand",

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 thiserror = "1.0.62"
 tokio = { version = "1.38.1", features = ["io-util"] }
+rand = "0.8.4"

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.86"
 async-trait = "0.1.81"
 aws-config = "1.5.4"
-aws-s3-transfer-manager = { git = "ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git", branch = "main" }
+aws-s3-transfer-manager = { git = "ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "d085949e930b0ef99031c0fd33c24d6c68fac4dd" }
 aws-sdk-s3 = "1.41.0"
 clap = { version = "4.5.9", features = ["derive"] }
 futures = "0.3.30"

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -16,3 +16,4 @@ serde_json = "1.0.120"
 thiserror = "1.0.62"
 tokio = { version = "1.38.1", features = ["io-util"] }
 rand = "0.8.4"
+bytes = "1"

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -15,5 +15,5 @@ serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 thiserror = "1.0.62"
 tokio = { version = "1.38.1", features = ["io-util"] }
-rand = "0.8.4"
 bytes = "1"
+fastrand = "=2.1.0"

--- a/runners/s3-benchrunner-rust/src/lib.rs
+++ b/runners/s3-benchrunner-rust/src/lib.rs
@@ -59,7 +59,7 @@ pub struct TaskConfig {
 }
 
 /// Possible values for the "action" field of the workload's JSON file
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum TaskAction {
     Download,

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -143,9 +143,10 @@ impl TransferManagerRunner {
     async fn upload(&self, task_config: &TaskConfig) -> Result<()> {
         let key = &task_config.key;
 
-        let stream = match self.config().workload.files_on_disk {
-            true => InputStream::from_path(key).with_context(|| "Failed to create stream")?,
-            false => self.handle.random_data_for_upload.clone().into(),
+        let stream = if self.config().workload.files_on_disk {
+            InputStream::from_path(key).with_context(|| "Failed to create stream")?
+        } else {
+            self.handle.random_data_for_upload.clone().into()
         };
 
         self.handle

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -120,7 +120,7 @@ impl TransferManagerRunner {
         let key = &task_config.key;
 
         let stream = match self.config().workload.files_on_disk {
-            true=> InputStream::from_path(key).with_context(|| "Failed to create stream")?,
+            true => InputStream::from_path(key).with_context(|| "Failed to create stream")?,
             false => {
                 // TODO: What is a better way to do this?
                 let mut data = Vec::new();
@@ -144,7 +144,6 @@ impl TransferManagerRunner {
 
         Ok(())
     }
-
 }
 
 #[async_trait]

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{iter::repeat_with, sync::Arc};
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -56,9 +56,8 @@ impl TransferManagerRunner {
                 .unwrap()
         };
         let random_data_for_upload: Bytes = {
-            // TODO: More efficient way to generate random buffer
-            let mut data = Vec::new();
-            data.resize_with(upload_data_size, rand::random::<u8>);
+            let mut rng = fastrand::Rng::new();
+            let data: Vec<u8> = repeat_with(|| rng.u8(..)).take(10_000).collect();
             data.into()
         };
 

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -13,10 +13,8 @@ use tokio::task::JoinSet;
 
 use crate::{
     BenchmarkConfig, Result, RunBenchmark, RunnerError, TaskAction, TaskConfig, PART_SIZE,
-
 };
 use bytes::Bytes;
-
 
 /// Benchmark runner using aws-s3-transfer-manager
 #[derive(Clone)]
@@ -46,7 +44,9 @@ impl TransferManagerRunner {
         let upload_data_size: usize = if config.workload.files_on_disk {
             0
         } else {
-            config.workload.tasks
+            config
+                .workload
+                .tasks
                 .iter()
                 .filter(|task| task.action == TaskAction::Upload)
                 .map(|task| task.size)
@@ -56,7 +56,7 @@ impl TransferManagerRunner {
                 .unwrap()
         };
         let random_data_for_upload: Bytes = {
-            let mut data = Vec::new(); 
+            let mut data = Vec::new();
             data.resize_with(upload_data_size, rand::random::<u8>);
             data.into()
         };
@@ -145,9 +145,8 @@ impl TransferManagerRunner {
 
         let stream = match self.config().workload.files_on_disk {
             true => InputStream::from_path(key).with_context(|| "Failed to create stream")?,
-            false => self.handle.random_data_for_upload.clone().into(), 
+            false => self.handle.random_data_for_upload.clone().into(),
         };
-
 
         self.handle
             .transfer_manager

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -146,7 +146,10 @@ impl TransferManagerRunner {
         let stream = if self.config().workload.files_on_disk {
             InputStream::from_path(key).with_context(|| "Failed to create stream")?
         } else {
-            self.handle.random_data_for_upload.slice(0..(task_config.size as usize)).into()
+            self.handle
+                .random_data_for_upload
+                .slice(0..(task_config.size as usize))
+                .into()
         };
 
         self.handle

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -57,7 +57,7 @@ impl TransferManagerRunner {
         };
         let random_data_for_upload: Bytes = {
             let mut rng = fastrand::Rng::new();
-            let data: Vec<u8> = repeat_with(|| rng.u8(..)).take(10_000).collect();
+            let data: Vec<u8> = repeat_with(|| rng.u8(..)).take(upload_data_size).collect();
             data.into()
         };
 

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -146,7 +146,7 @@ impl TransferManagerRunner {
         let stream = if self.config().workload.files_on_disk {
             InputStream::from_path(key).with_context(|| "Failed to create stream")?
         } else {
-            self.handle.random_data_for_upload.clone().into()
+            self.handle.random_data_for_upload.slice(0..(task_config.size as usize)).into()
         };
 
         self.handle

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -56,6 +56,7 @@ impl TransferManagerRunner {
                 .unwrap()
         };
         let random_data_for_upload: Bytes = {
+            // TODO: More efficient way to generate random buffer
             let mut data = Vec::new();
             data.resize_with(upload_data_size, rand::random::<u8>);
             data.into()


### PR DESCRIPTION
*Description of changes:*
- Sync to the latest commit of the Rust transfer manager
- Add support for benchmarking uploads

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
