### PR TITLE
bump AWS SDK Java version

### DIFF
--- a/runners/s3-benchrunner-java/pom.xml
+++ b/runners/s3-benchrunner-java/pom.xml
@@ -10,8 +10,8 @@
 
   <properties>
     <!-- build with -Dawscrt.version=1.0.0-SNAPSHOT to use the locally installed dev version) -->
-    <awscrt.version>[0.29,)</awscrt.version>
-    <aws.sdk.version>[2.25,)</aws.sdk.version>
+    <awscrt.version>[0.30,)</awscrt.version>
+    <aws.sdk.version>[2.27,)</aws.sdk.version>
 
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION

AWS SDK for Java version 2.27.x


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
