### PR TITLE
Use recv path

### DIFF
--- a/runners/s3-benchrunner-java/pom.xml
+++ b/runners/s3-benchrunner-java/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <!-- build with -Dawscrt.version=1.0.0-SNAPSHOT to use the locally installed dev version) -->
-    <awscrt.version>[0.30,)</awscrt.version>
+    <awscrt.version>[0.30.10,)</awscrt.version>
     <aws.sdk.version>[2.27,)</aws.sdk.version>
 
     <maven.compiler.release>17</maven.compiler.release>

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/Main.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/Main.java
@@ -11,8 +11,9 @@ public class Main {
     /////////////// BEGIN ARBITRARY HARDCODED VALUES ///////////////
 
     // 256MiB is Java Transfer Mgr v2 default.
-    // TODO: Investigate. At time of writing, this noticeably impacts performance.
-    public static final int BACKPRESSURE_INITIAL_READ_WINDOW_MiB = 256;
+    // This benchmark can turn off backpressure and rely solely on the
+    // memory-limiter.
+    public static final int BACKPRESSURE_INITIAL_READ_WINDOW_MiB = 0;
 
     /////////////// END ARBITRARY HARD-CODED VALUES ///////////////
 

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
@@ -78,7 +78,7 @@ public class CRTJavaBenchmarkRunner extends BenchmarkRunner {
         // If writing data to disk, enable backpressure.
         // This prevents us from running out of memory due to downloading
         // data faster than we can write it to disk.
-        if (config.filesOnDisk && Main.BACKPRESSURE_INITIAL_READ_WINDOW_MiB!=0) {
+        if (config.filesOnDisk && Main.BACKPRESSURE_INITIAL_READ_WINDOW_MiB != 0) {
             s3ClientOpts.withReadBackpressureEnabled(true);
             s3ClientOpts.withInitialReadWindowSize(Util.bytesFromMiB(Main.BACKPRESSURE_INITIAL_READ_WINDOW_MiB));
         }

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaBenchmarkRunner.java
@@ -78,7 +78,7 @@ public class CRTJavaBenchmarkRunner extends BenchmarkRunner {
         // If writing data to disk, enable backpressure.
         // This prevents us from running out of memory due to downloading
         // data faster than we can write it to disk.
-        if (config.filesOnDisk) {
+        if (config.filesOnDisk && Main.BACKPRESSURE_INITIAL_READ_WINDOW_MiB!=0) {
             s3ClientOpts.withReadBackpressureEnabled(true);
             s3ClientOpts.withInitialReadWindowSize(Util.bytesFromMiB(Main.BACKPRESSURE_INITIAL_READ_WINDOW_MiB));
         }

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaTask.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaTask.java
@@ -8,9 +8,7 @@ import software.amazon.awssdk.crt.http.HttpRequest;
 import software.amazon.awssdk.crt.http.HttpRequestBodyStream;
 import software.amazon.awssdk.crt.s3.*;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -24,7 +22,6 @@ class CRTJavaTask implements S3MetaRequestResponseHandler {
     TaskConfig config;
     S3MetaRequest metaRequest;
     CompletableFuture<Void> doneFuture;
-    ReadableByteChannel uploadFileChannel;
 
     CRTJavaTask(CRTJavaBenchmarkRunner runner, int taskI) {
         this.runner = runner;
@@ -111,14 +108,6 @@ class CRTJavaTask implements S3MetaRequestResponseHandler {
             Util.exitWithError("S3MetaRequest failed");
         } else {
             // CRTJavaTask succeeded. Clean up...
-            try {
-                if (uploadFileChannel != null) {
-                    uploadFileChannel.close();
-                }
-            } catch (IOException e) {
-                Util.exitWithError("Failed closing file: " + e.toString());
-            }
-
             // work around API-gotcha where callbacks can fire on other threads
             // before makeMetaRequest() has returned
             synchronized (this) {

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaTask.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/crtjava/CRTJavaTask.java
@@ -10,12 +10,9 @@ import software.amazon.awssdk.crt.s3.*;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -28,7 +25,6 @@ class CRTJavaTask implements S3MetaRequestResponseHandler {
     S3MetaRequest metaRequest;
     CompletableFuture<Void> doneFuture;
     ReadableByteChannel uploadFileChannel;
-    WritableByteChannel downloadFileChannel;
 
     CRTJavaTask(CRTJavaBenchmarkRunner runner, int taskI) {
         this.runner = runner;
@@ -66,12 +62,7 @@ class CRTJavaTask implements S3MetaRequestResponseHandler {
             headers.add(new HttpHeader("Content-Length", "0"));
 
             if (runner.config.filesOnDisk) {
-                try {
-                    downloadFileChannel = FileChannel.open(Path.of(config.key),
-                            StandardOpenOption.CREATE, StandardOpenOption.WRITE);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
+                options.withResponseFilePath(Path.of(config.key));
             }
         } else {
             throw new RuntimeException("Unknown task action: " + config.action);
@@ -103,21 +94,6 @@ class CRTJavaTask implements S3MetaRequestResponseHandler {
     }
 
     @Override
-    public int onResponseBody(ByteBuffer bodyBytesIn, long objectRangeStart, long objectRangeEnd) {
-        int amountReceived = bodyBytesIn.remaining();
-
-        if (downloadFileChannel != null) {
-            try {
-                downloadFileChannel.write(bodyBytesIn);
-            } catch (IOException e) {
-                Util.exitWithError("Failed writing to file: " + e.toString());
-            }
-        }
-
-        return amountReceived;
-    }
-
-    @Override
     public void onFinished(S3FinishedResponseContext context) {
         if (context.getErrorCode() != 0) {
             // CRTJavaTask failed. Report error and kill program...
@@ -136,9 +112,6 @@ class CRTJavaTask implements S3MetaRequestResponseHandler {
         } else {
             // CRTJavaTask succeeded. Clean up...
             try {
-                if (downloadFileChannel != null) {
-                    downloadFileChannel.close();
-                }
                 if (uploadFileChannel != null) {
                     uploadFileChannel.close();
                 }


### PR DESCRIPTION
*Issue #, if available:*
- Use recv path directly instead of implement our own way to write to file
- Disable the backpressure for crt-java as well, similar to https://github.com/awslabs/aws-crt-s3-benchmarks/pull/70

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
