### PR TITLE
Add OpenTelemetry to Rust benchmark runner

### DIFF
--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -232,6 +232,7 @@ dependencies = [
 [[package]]
 name = "aws-s3-transfer-manager"
 version = "0.1.0"
+source = "git+ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git?rev=e929fac22a4aeb49b4ef1953324e8fcd54822aff#e929fac22a4aeb49b4ef1953324e8fcd54822aff"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -241,8 +242,10 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "futures-util",
  "hyper",
  "path-clean",
+ "pin-project-lite",
  "tokio",
  "tower 0.5.1",
  "tracing",

--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -232,7 +232,6 @@ dependencies = [
 [[package]]
 name = "aws-s3-transfer-manager"
 version = "0.1.0"
-source = "git+ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git?rev=d2e1e164de35b3cdc34193a2a1721a63f959752f#d2e1e164de35b3cdc34193a2a1721a63f959752f"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -242,10 +241,8 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "futures-util",
  "hyper",
  "path-clean",
- "pin-project-lite",
  "tokio",
  "tower 0.5.1",
  "tracing",

--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -1070,28 +1070,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -1110,12 +1094,6 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
-
-[[package]]
-name = "futures-io"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
@@ -1146,13 +1124,10 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1689,23 +1664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1869fb4bb9b35c5ba8a1e40c9b128a7b4c010d07091e864a29da19e4fe2ca4d7"
 
 [[package]]
-name = "opentelemetry-stdout"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d080bf06af02b738feb2e6830cf72c30b76ca18b40f555cdf1b53e7b491bfe"
-dependencies = [
- "async-trait",
- "chrono",
- "futures-util",
- "opentelemetry",
- "opentelemetry_sdk",
- "ordered-float",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "opentelemetry_sdk"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,7 +1680,6 @@ dependencies = [
  "ordered-float",
  "percent-encoding",
  "rand",
- "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2107,18 +2064,15 @@ dependencies = [
  "bytes",
  "clap",
  "fastrand",
- "futures",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
- "opentelemetry-stdout",
  "opentelemetry_sdk",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tracing",
- "tracing-core",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]

--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -123,6 +123,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,7 +247,7 @@ dependencies = [
  "path-clean",
  "pin-project-lite",
  "tokio",
- "tower",
+ "tower 0.5.1",
  "tracing",
 ]
 
@@ -482,7 +504,7 @@ dependencies = [
  "httparse",
  "hyper",
  "hyper-rustls",
- "indexmap",
+ "indexmap 2.5.0",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -561,6 +583,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +672,12 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -626,6 +699,18 @@ checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1101,6 +1186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,7 +1214,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1145,6 +1236,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1292,6 +1389,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,12 +1412,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -1319,10 +1438,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1348,7 +1485,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1359,6 +1496,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "md-5"
@@ -1375,6 +1518,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1490,6 +1639,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1869fb4bb9b35c5ba8a1e40c9b128a7b4c010d07091e864a29da19e4fe2ca4d7"
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6d080bf06af02b738feb2e6830cf72c30b76ca18b40f555cdf1b53e7b491bfe"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "ordered-float",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "lazy_static",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "percent-encoding",
+ "rand",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a91171844676f8c7990ce64959210cd2eaef32c2612c50f9fae9f8aaa6065a6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1779,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1825,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -1602,12 +1879,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
@@ -1763,6 +2084,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,10 +2108,19 @@ dependencies = [
  "clap",
  "fastrand",
  "futures",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-core",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1826,7 +2162,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1891,7 +2227,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap",
+ "indexmap 2.5.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2128,6 +2464,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,6 +2516,53 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2231,6 +2635,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -2366,6 +2788,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,6 +2974,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# aws-s3-transfer-manager = { git = "ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "d2e1e164de35b3cdc34193a2a1721a63f959752f" }
+aws-s3-transfer-manager = { path = "../../../aws-s3-transfer-manager-rs/aws-s3-transfer-manager" }
+
 anyhow = "1.0.86"
 async-trait = "0.1.81"
 aws-config = "1.5.4"
-aws-s3-transfer-manager = { git = "ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "d2e1e164de35b3cdc34193a2a1721a63f959752f" }
 aws-sdk-s3 = "1.41.0"
 clap = { version = "4.5.9", features = ["derive"] }
 futures = "0.3.30"
@@ -17,12 +19,16 @@ thiserror = "1.0.62"
 tokio = { version = "1.38.1", features = ["io-util"] }
 bytes = "1"
 fastrand = "=2.1.0"
-tracing-subscriber = "0.3.18"
-tracing = "0.1.40"
+
+# NOTE: tracing-opentelemetry 0.26.0 is a bit broken (see https://github.com/tokio-rs/tracing-opentelemetry/issues/159)
+# so using 0.24.0 and the exact opentelemetry-* versions it depends on.
+tracing-opentelemetry = "0.24.0"
 opentelemetry = { version = "0.23", features = ["trace", "metrics"] }
 opentelemetry_sdk = { version = "0.23", default-features = false, features = ["trace", "rt-tokio"] }
 opentelemetry-stdout = { version = "0.4.0", features = ["trace", "metrics"] }
 opentelemetry-otlp = { version = "0.16", features = ["metrics"] }
 opentelemetry-semantic-conventions = "0.15.0"
-tracing-core = "0.1.28"
-tracing-opentelemetry = "0.24.0"
+
+tracing = "0.1.40"
+tracing-core = "0.1.32"
+tracing-subscriber = "0.3.18"

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -17,3 +17,12 @@ thiserror = "1.0.62"
 tokio = { version = "1.38.1", features = ["io-util"] }
 bytes = "1"
 fastrand = "=2.1.0"
+tracing-subscriber = "0.3.18"
+tracing = "0.1.40"
+opentelemetry = { version = "0.23", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.23", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-stdout = { version = "0.4.0", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.16", features = ["metrics"] }
+opentelemetry-semantic-conventions = "0.15.0"
+tracing-core = "0.1.28"
+tracing-opentelemetry = "0.24.0"

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -16,7 +16,6 @@ opentelemetry = { version = "0.23", features = ["trace", "metrics"] }
 opentelemetry_sdk = { version = "0.23", default-features = false, features = ["trace", "rt-tokio"] }
 opentelemetry-otlp = { version = "0.16", features = ["metrics"] }
 opentelemetry-semantic-conventions = "0.15.0"
-opentelemetry-stdout = { version = "0.4.0", features = ["trace", "metrics"] }
 
 anyhow = "1.0.86"
 async-trait = "0.1.81"
@@ -25,11 +24,9 @@ aws-sdk-s3 = "1.41.0"
 bytes = "1"
 clap = { version = "4.5.9", features = ["derive"] }
 fastrand = "=2.1.0"
-futures = "0.3.30"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 thiserror = "1.0.62"
 tokio = { version = "1.38.1", features = ["io-util"] }
 tracing = "0.1.40"
-tracing-core = "0.1.32"
 tracing-subscriber = "0.3.18"

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -4,31 +4,32 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# aws-s3-transfer-manager = { git = "ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "d2e1e164de35b3cdc34193a2a1721a63f959752f" }
-aws-s3-transfer-manager = { path = "../../../aws-s3-transfer-manager-rs/aws-s3-transfer-manager" }
+
+# Swap which line is commented-out to use GitHub or local aws-s3-transfer-manager
+aws-s3-transfer-manager = { git = "ssh://git@github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "e929fac22a4aeb49b4ef1953324e8fcd54822aff" }
+# aws-s3-transfer-manager = { path = "../../../aws-s3-transfer-manager-rs/aws-s3-transfer-manager" }
+
+# tracing-opentelemetry 0.26.0 is a bit broken (see https://github.com/tokio-rs/tracing-opentelemetry/issues/159)
+# so use 0.24.0 and the exact opentelemetry-* versions it depends on.
+tracing-opentelemetry = "0.24.0"
+opentelemetry = { version = "0.23", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.23", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-otlp = { version = "0.16", features = ["metrics"] }
+opentelemetry-semantic-conventions = "0.15.0"
+opentelemetry-stdout = { version = "0.4.0", features = ["trace", "metrics"] }
 
 anyhow = "1.0.86"
 async-trait = "0.1.81"
 aws-config = "1.5.4"
 aws-sdk-s3 = "1.41.0"
+bytes = "1"
 clap = { version = "4.5.9", features = ["derive"] }
+fastrand = "=2.1.0"
 futures = "0.3.30"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 thiserror = "1.0.62"
 tokio = { version = "1.38.1", features = ["io-util"] }
-bytes = "1"
-fastrand = "=2.1.0"
-
-# NOTE: tracing-opentelemetry 0.26.0 is a bit broken (see https://github.com/tokio-rs/tracing-opentelemetry/issues/159)
-# so using 0.24.0 and the exact opentelemetry-* versions it depends on.
-tracing-opentelemetry = "0.24.0"
-opentelemetry = { version = "0.23", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.23", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-stdout = { version = "0.4.0", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.16", features = ["metrics"] }
-opentelemetry-semantic-conventions = "0.15.0"
-
 tracing = "0.1.40"
 tracing-core = "0.1.32"
 tracing-subscriber = "0.3.18"

--- a/runners/s3-benchrunner-rust/README.md
+++ b/runners/s3-benchrunner-rust/README.md
@@ -14,7 +14,7 @@ This produces: `target/release/s3-benchrunner-rust`
 ## Running
 
 ```
-Usage: s3-benchrunner-rust <S3_CLIENT> <WORKLOAD> <BUCKET> <REGION> <TARGET_THROUGHPUT>
+Usage: s3-benchrunner-rust [OPTIONS] <S3_CLIENT> <WORKLOAD> <BUCKET> <REGION> <TARGET_THROUGHPUT>
 
 Arguments:
   <S3_CLIENT>
@@ -36,8 +36,19 @@ Arguments:
           Target throughput, in gigabits per second (e.g. "100.0" for c5n.18xlarge)
 
 Options:
+      --telemetry
+          Emit telemetry via OTLP/gRPC to http://localhost:4317
+
   -h, --help
           Print help (see a summary with '-h')
 ```
 
 See further instructions [here](../../README.md#run-a-benchmark).
+
+### Viewing Telemetry
+
+Use the `--telemetry` flag to export OpenTelemetry data to  http://localhost:4317 as OTLP/gRPC payloads.
+
+The simplest way I know collect and view this data is with [Jaeger All in One](https://www.jaegertracing.io/docs/latest/getting-started/) or [otel-desktop-viewer](https://github.com/CtrlSpice/otel-desktop-viewer?tab=readme-ov-file#getting-started). Get one of these running, run the benchmark with the `--telemetry` flag, then view the data in your browser.
+
+TODO: document how to collect and view data from a non-local run.

--- a/runners/s3-benchrunner-rust/src/lib.rs
+++ b/runners/s3-benchrunner-rust/src/lib.rs
@@ -3,6 +3,8 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use std::{fs::File, io::BufReader, path::Path};
 
+pub mod telemetry;
+
 mod transfer_manager;
 pub use transfer_manager::TransferManagerRunner;
 

--- a/runners/s3-benchrunner-rust/src/lib.rs
+++ b/runners/s3-benchrunner-rust/src/lib.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::{fs::File, io::BufReader, path::Path};
-use tracing::instrument;
 
 pub mod telemetry;
 
@@ -122,7 +121,6 @@ pub trait RunBenchmark {
 }
 
 // Do prep work between runs, before timers starts (e.g. create intermediate directories)
-#[instrument(skip_all, level = "debug")]
 pub fn prepare_run(workload: &WorkloadConfig) -> Result<()> {
     if workload.files_on_disk {
         for task_config in &workload.tasks {

--- a/runners/s3-benchrunner-rust/src/lib.rs
+++ b/runners/s3-benchrunner-rust/src/lib.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::{fs::File, io::BufReader, path::Path};
+use tracing::instrument;
 
 pub mod telemetry;
 
@@ -121,6 +122,7 @@ pub trait RunBenchmark {
 }
 
 // Do prep work between runs, before timers starts (e.g. create intermediate directories)
+#[instrument(skip_all, level = "debug")]
 pub fn prepare_run(workload: &WorkloadConfig) -> Result<()> {
     if workload.files_on_disk {
         for task_config in &workload.tasks {

--- a/runners/s3-benchrunner-rust/src/main.rs
+++ b/runners/s3-benchrunner-rust/src/main.rs
@@ -99,7 +99,6 @@ async fn execute(args: &Args) -> Result<()> {
     Ok(())
 }
 
-#[instrument(skip_all, level = "debug")]
 async fn new_runner(args: &Args) -> Result<Box<dyn RunBenchmark>> {
     let config = BenchmarkConfig::new(
         &args.workload,

--- a/runners/s3-benchrunner-rust/src/telemetry.rs
+++ b/runners/s3-benchrunner-rust/src/telemetry.rs
@@ -1,5 +1,13 @@
 //! code adapted from: https://github.com/tokio-rs/tracing-opentelemetry/blob/v0.24.0/examples/opentelemetry-otlp.rs
 
+// Avoid adding `use` declarations to the top of this file.
+// If you MUST shorten a path, add the `use` within a function.
+// The examples this code is adapted from had `use` declarations, and
+// I (graebm) found it hard to understand what all the boilerplate was doing.
+// With full paths, it's clear that the boilerplate is about tying together
+// different ecosystems (`opentelemetry` vs `tracing`). These ecosystems
+// split their features among many crates, and full paths make it more clear.
+
 use anyhow::Context;
 
 use crate::Result;

--- a/runners/s3-benchrunner-rust/src/telemetry.rs
+++ b/runners/s3-benchrunner-rust/src/telemetry.rs
@@ -1,0 +1,71 @@
+//! code adapted from: https://github.com/tokio-rs/tracing-opentelemetry/blob/v0.24.0/examples/opentelemetry-otlp.rs
+
+use anyhow::Context;
+
+use crate::Result;
+
+// Create OTEL Resource (the entity that produces telemetry)
+fn otel_resource() -> opentelemetry_sdk::Resource {
+    use opentelemetry::KeyValue;
+    use opentelemetry_semantic_conventions::{
+        resource::{DEPLOYMENT_ENVIRONMENT, SERVICE_NAME, SERVICE_VERSION},
+        SCHEMA_URL,
+    };
+
+    opentelemetry_sdk::Resource::from_schema_url(
+        [
+            KeyValue::new(SERVICE_NAME, env!("CARGO_PKG_NAME")),
+            KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+            KeyValue::new(DEPLOYMENT_ENVIRONMENT, "develop"),
+        ],
+        SCHEMA_URL,
+    )
+}
+
+// Construct OpenTelemetry Tracer
+fn new_otel_tracer() -> Result<opentelemetry_sdk::trace::Tracer> {
+    use opentelemetry_sdk::trace::Sampler;
+
+    opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_trace_config(
+            opentelemetry_sdk::trace::Config::default()
+                // Customize sampling strategy
+                .with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+                    1.0,
+                ))))
+                // If export trace to AWS X-Ray, you can use XrayIdGenerator
+                .with_id_generator(opentelemetry_sdk::trace::RandomIdGenerator::default())
+                .with_resource(otel_resource()),
+        )
+        .with_batch_config(opentelemetry_sdk::trace::BatchConfig::default())
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
+        .install_batch(opentelemetry_sdk::runtime::Tokio)
+        .with_context(|| format!(""))
+}
+
+/// TelemetryGuard ensures data gets flushed when the guard goes out of scope.
+pub struct TelemetryGuard {}
+
+impl Drop for TelemetryGuard {
+    fn drop(&mut self) {
+        opentelemetry::global::shutdown_tracer_provider();
+    }
+}
+
+pub fn init_tracing_subscriber() -> Result<TelemetryGuard> {
+    let otel_tracer = new_otel_tracer()?;
+
+    // We want data emitted from the `tracing` crate to be exported as OpenTelemetry data.
+    // To do this, register an `OpenTelemetryLayer` as a `tracing_subscriber`.
+    use tracing_subscriber::prelude::*;
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::filter::LevelFilter::from_level(
+            tracing::Level::INFO,
+        ))
+        .with(tracing_opentelemetry::OpenTelemetryLayer::new(otel_tracer))
+        .init();
+
+    Ok(TelemetryGuard {})
+}

--- a/runners/s3-benchrunner-rust/src/telemetry.rs
+++ b/runners/s3-benchrunner-rust/src/telemetry.rs
@@ -58,6 +58,14 @@ pub fn init_tracing_subscriber() -> Result<TelemetryGuard> {
 
     // We want data emitted from the `tracing` crate to be exported as OpenTelemetry data.
     // To do this, register an `OpenTelemetryLayer` as a `tracing_subscriber`.
+    //
+    // TODO: stop using `tracing_opentelemetry::OpenTelemetryLayer` (from makers of Tokio)
+    // when OpenTelemetry adds `tracing` integration in the OpenTelemetry SDK itself.
+    // - We've had issues where these crates don't all work together:
+    //   https://github.com/tokio-rs/tracing-opentelemetry/issues/159
+    // - OpenTelemetry says they're working on adding on their own integration:
+    //   https://github.com/open-telemetry/opentelemetry-rust/issues/1571#issuecomment-2258910019)
+
     use tracing_subscriber::prelude::*;
 
     tracing_subscriber::registry()


### PR DESCRIPTION
Get started adding observability, so we can diagnose bottlenecks.

Many crates (including the AWS SDK for Rust) use the [tracing](https://docs.rs/tracing/latest/tracing/index.html) crate to emit Spans and Events. We want to view this data.

[OpenTelemetry](https://opentelemetry.io/) is a widely use ecosystem for viewing this kind of data, so let's use the [opentelemetry-* crates](https://opentelemetry.io/docs/languages/rust/) (various features are split among various crates).

[OTLP/gRPC](https://opentelemetry.io/docs/specs/otlp/) (OpenTelemetry Protocol) is a popular and platform-agnostic way to export this data, so let's use the [opentelemetry-otlp crate](https://crates.io/crates/opentelemetry-otlp).

The [tracing-opentelemetry](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/) crate exists to help pipe data from `tracing` to an `opentelemetry::trace::Tracer`, so let's use that.

There's lots more to do. Currently, it's hard-coded to only view "info" level data because "debug" was too much. I'm still learning how to filter for the exact data we're interested in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
