### PR TITLE
Improve Rust tracing spans

### DIFF
--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "aws-s3-transfer-manager"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-s3-transfer-manager-rs.git?rev=33031d9945cd9961bb5e1b5207ac8870b0a9dbbd#33031d9945cd9961bb5e1b5207ac8870b0a9dbbd"
+source = "git+https://github.com/awslabs/aws-s3-transfer-manager-rs.git?rev=790ead476a104cf0b66fdd00b5b9c3636321b244#790ead476a104cf0b66fdd00b5b9c3636321b244"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "aws-s3-transfer-manager"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-s3-transfer-manager-rs.git?rev=3dd20c8aa0872352100cf456beee02bfc53c73d1#3dd20c8aa0872352100cf456beee02bfc53c73d1"
+source = "git+https://github.com/awslabs/aws-s3-transfer-manager-rs.git?rev=33031d9945cd9961bb5e1b5207ac8870b0a9dbbd#33031d9945cd9961bb5e1b5207ac8870b0a9dbbd"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 
 # Swap which line is commented-out to use GitHub or local aws-s3-transfer-manager
-aws-s3-transfer-manager = { git = "https://github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "3dd20c8aa0872352100cf456beee02bfc53c73d1" }
+aws-s3-transfer-manager = { git = "https://github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "33031d9945cd9961bb5e1b5207ac8870b0a9dbbd" }
 # aws-s3-transfer-manager = { path = "../../../aws-s3-transfer-manager-rs/aws-s3-transfer-manager" }
 
 tracing-opentelemetry = "0.27"

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 
 # Swap which line is commented-out to use GitHub or local aws-s3-transfer-manager
-aws-s3-transfer-manager = { git = "https://github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "33031d9945cd9961bb5e1b5207ac8870b0a9dbbd" }
+aws-s3-transfer-manager = { git = "https://github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "790ead476a104cf0b66fdd00b5b9c3636321b244" }
 # aws-s3-transfer-manager = { path = "../../../aws-s3-transfer-manager-rs/aws-s3-transfer-manager" }
 
 tracing-opentelemetry = "0.27"

--- a/runners/s3-benchrunner-rust/graph.py
+++ b/runners/s3-benchrunner-rust/graph.py
@@ -28,13 +28,22 @@ PARSER.add_argument('TRACE_JSON', help="trace_*.json file to graph.")
 
 args = PARSER.parse_args()
 
-with PerfTimer(f'Open {args.TRACE_JSON}'):
-    with open(args.TRACE_JSON) as f:
+trace_json = Path(args.TRACE_JSON)
+
+# if directory passed in, pick the newest file
+if trace_json.is_dir():
+    all_traces = list(trace_json.glob('trace_*.json'))
+    if len(all_traces) == 0:
+        exit(f"No trace_*.json found under: {trace_json.absolute()}")
+    trace_json = sorted(all_traces, key=lambda x: x.stat().st_mtime)[-1]
+
+with PerfTimer(f'Open {trace_json}'):
+    with open(trace_json) as f:
         traces_data = json.load(f)
 
 with PerfTimer('Graph all spans'):
     fig = graph.allspans.draw(traces_data)
 
-html_path = Path(args.TRACE_JSON).with_suffix('.html')
+html_path = Path(trace_json).with_suffix('.allspans.html')
 with PerfTimer(f'Write {html_path}'):
     fig.write_html(html_path)

--- a/runners/s3-benchrunner-rust/graph/allspans.py
+++ b/runners/s3-benchrunner-rust/graph/allspans.py
@@ -21,24 +21,29 @@ def draw(data):
     columns = defaultdict(list)
     name_count = defaultdict(int)
     for (idx, span) in enumerate(spans):
-
         name = span['name']
         # we want each span in its own row, so assign a unique name and use that as Y value
         # TODO: improve unique name, using "seq" or "part-num"
         name_count[name] += 1
         unique_name = f"{name}#{name_count[name]}"
 
+        start_time_ns = span['startTimeUnixNano']
+        end_time_ns = span['endTimeUnixNano']
+        duration_ns = end_time_ns - start_time_ns
+        # ensure span is wide enough to see
+        visual_end_time_ns = start_time_ns + max(duration_ns, 50_000_000)
+
         columns['Name'].append(name)
         columns['Unique Name'].append(unique_name)
-        columns['Duration (ns)'].append(
-            span['endTimeUnixNano'] - span['startTimeUnixNano'])
-        columns['Start Time'].append(pd.to_datetime(span['startTimeUnixNano']))
-        columns['End Time'].append(pd.to_datetime(span['endTimeUnixNano']))
+        columns['Start Time'].append(pd.to_datetime(start_time_ns))
+        columns['End Time'].append(pd.to_datetime(end_time_ns))
+        columns['Visual End Time'].append(pd.to_datetime(visual_end_time_ns))
+        columns['Duration (secs)'].append(duration_ns / 1_000_000_000.0)
         columns['Index'].append(idx)
         columns['Span ID'].append(span['spanId'])
         columns['Parent ID'].append(span['parentSpanId'])
         columns['Attributes'].append(
-            [f"<br>  {k}: {v}" for (k, v) in span['attributes'].items()])
+            "".join([f"<br>  {k}={v}" for (k, v) in span['attributes'].items()]))
 
     # if a span name occurs only once, remove the "#1" from its unique name
     for (i, name) in enumerate(columns['Name']):
@@ -50,14 +55,13 @@ def draw(data):
     # By default, show all columns in hover text.
     # Omit a column by setting false. You can also set special formatting rules here.
     hover_data = {col: True for col in columns.keys()}
-    hover_data['Name'] = False  # already shown
     hover_data['Unique Name'] = False  # already shown
-    hover_data['End Time'] = False  # who cares
+    hover_data['Visual End Time'] = False  # actual "End Time" already shown
 
     fig = px.timeline(
         data_frame=df,
         x_start='Start Time',
-        x_end='End Time',
+        x_end='Visual End Time',
         y='Unique Name',
         hover_data=hover_data,
         # spans with same original name get same color
@@ -154,6 +158,11 @@ def _simplify_attributes(attributes_list):
         if key == 'code.filepath':
             if (src_idx := value.find("src/")) > 0:
                 value = value[src_idx:]
+
+        # trim down excessively long strings
+        MAX_STRLEN = 150
+        if isinstance(value, str) and len(value) > MAX_STRLEN:
+            value = value[:MAX_STRLEN] + "...TRUNCATED"
 
         simple_dict[key] = value
 

--- a/runners/s3-benchrunner-rust/graph/allspans.py
+++ b/runners/s3-benchrunner-rust/graph/allspans.py
@@ -22,10 +22,11 @@ def draw(data):
     name_count = defaultdict(int)
     for (idx, span) in enumerate(spans):
         name = span['name']
+        # nice name includes stuff like part-number
+        nice_name = _nice_name(span)
         # we want each span in its own row, so assign a unique name and use that as Y value
-        # TODO: improve unique name, using "seq" or "part-num"
-        name_count[name] += 1
-        unique_name = f"{name}#{name_count[name]}"
+        name_count[nice_name] += 1
+        unique_name = f"{nice_name} ({span['spanId']})"
 
         start_time_ns = span['startTimeUnixNano']
         end_time_ns = span['endTimeUnixNano']
@@ -34,21 +35,21 @@ def draw(data):
         visual_end_time_ns = start_time_ns + max(duration_ns, 50_000_000)
 
         columns['Name'].append(name)
+        columns['Nice Name'].append(nice_name)
         columns['Unique Name'].append(unique_name)
         columns['Start Time'].append(pd.to_datetime(start_time_ns))
         columns['End Time'].append(pd.to_datetime(end_time_ns))
         columns['Visual End Time'].append(pd.to_datetime(visual_end_time_ns))
         columns['Duration (secs)'].append(duration_ns / 1_000_000_000.0)
-        columns['Index'].append(idx)
         columns['Span ID'].append(span['spanId'])
         columns['Parent ID'].append(span['parentSpanId'])
         columns['Attributes'].append(
             "".join([f"<br>  {k}={v}" for (k, v) in span['attributes'].items()]))
 
-    # if a span name occurs only once, remove the "#1" from its unique name
+    # if a span name occurs only once, we can just use the nice_name
     for (i, name) in enumerate(columns['Name']):
         if name_count[name] == 1:
-            columns['Unique Name'][i] = name
+            columns['Unique Name'][i] = columns['Nice Name'][i]
 
     df = pd.DataFrame(columns)
 
@@ -167,3 +168,14 @@ def _simplify_attributes(attributes_list):
         simple_dict[key] = value
 
     return simple_dict
+
+
+def _nice_name(span):
+    name = span['name']
+    attributes = span['attributes']
+    if (seq := attributes.get('seq')) is not None:
+        name += f"[{seq}]"
+
+    if (part_number := attributes.get('part_number')) is not None:
+        name += f"#{part_number}"
+    return name

--- a/runners/s3-benchrunner-rust/src/main.rs
+++ b/runners/s3-benchrunner-rust/src/main.rs
@@ -80,7 +80,11 @@ async fn execute(args: &Args) -> Result<()> {
 
         runner
             .run()
-            .instrument(info_span!("run", num = run_num, workload = workload_name))
+            .instrument(info_span!(
+                "run-benchmark",
+                num = run_num,
+                workload = workload_name
+            ))
             .await?;
 
         let run_secs = run_start.elapsed().as_secs_f64();


### PR DESCRIPTION
Adapt to changes from https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/66
Now that the transfer manager has a lot of nice spans, we can trim some out of here.
Also, some tweaks to the graph.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
