### PR TITLE
Enable Lifecycle Rules for S3 Express

### DIFF
--- a/scripts/prep-s3-files.py
+++ b/scripts/prep-s3-files.py
@@ -174,6 +174,7 @@ def prep_bucket(s3, bucket: str, region: str):
     # Do this every time, in case the bucket was made by hand, or made by the CDK stack.
     s3.put_bucket_lifecycle_configuration(
         Bucket=bucket,
+        ChecksumAlgorithm='CRC32',
         LifecycleConfiguration={
             'Rules': [
                 {
@@ -183,7 +184,7 @@ def prep_bucket(s3, bucket: str, region: str):
                     'AbortIncompleteMultipartUpload': {'DaysAfterInitiation': 1},
                 },
                 {
-                    'ID': 'Objects under "upload/" expire after 1 day',
+                    'ID': 'Objects under upload directory expire after 1 day',
                     'Status': 'Enabled',
                     'Filter': {'Prefix': 'upload/'},
                     'Expiration': {'Days': 1},

--- a/scripts/prep-s3-files.py
+++ b/scripts/prep-s3-files.py
@@ -172,25 +172,23 @@ def prep_bucket(s3, bucket: str, region: str):
 
     # Set lifecycle rules on this bucket, so we don't waste money.
     # Do this every time, in case the bucket was made by hand, or made by the CDK stack.
-    # NOTE: S3 Express doesn't support lifecycle rules (as of March 2024).
-    if not is_s3express_bucket(bucket):
-        s3.put_bucket_lifecycle_configuration(
-            Bucket=bucket,
-            LifecycleConfiguration={
-                'Rules': [
-                    {
-                        'ID': 'Abort all incomplete multipart uploads after 1 day',
-                        'Status': 'Enabled',
-                        'Filter': {'Prefix': ''},  # blank string means all
-                        'AbortIncompleteMultipartUpload': {'DaysAfterInitiation': 1},
-                    },
-                    {
-                        'ID': 'Objects under "upload/" expire after 1 day',
-                        'Status': 'Enabled',
-                        'Filter': {'Prefix': 'upload/'},
-                        'Expiration': {'Days': 1},
-                    },
-                ]})
+    s3.put_bucket_lifecycle_configuration(
+        Bucket=bucket,
+        LifecycleConfiguration={
+            'Rules': [
+                {
+                    'ID': 'Abort all incomplete multipart uploads after 1 day',
+                    'Status': 'Enabled',
+                    'Filter': {'Prefix': ''},  # blank string means all
+                    'AbortIncompleteMultipartUpload': {'DaysAfterInitiation': 1},
+                },
+                {
+                    'ID': 'Objects under "upload/" expire after 1 day',
+                    'Status': 'Enabled',
+                    'Filter': {'Prefix': 'upload/'},
+                    'Expiration': {'Days': 1},
+                },
+            ]})
 
 
 @dataclass


### PR DESCRIPTION
*Description of changes:*
- S3Express didn't support lifecycle rules initially, but now it does. Enable the lifecycle rules to automatically clean up failed MPUs, which are taking up a lot of space in our S3Express bucket.
- Adds checksum=crc32, since without it, S3Express doesn't work and returns an error: "An error occurred (InvalidRequest) when calling the PutBucketLifecycleConfiguration operation: Missing required header for this request: Content-MD5 OR x-amz-checksum-*"
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
