### PR TITLE
Concurrency redux

### DIFF
--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
 [[package]]
 name = "aws-s3-transfer-manager"
 version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-s3-transfer-manager-rs.git?rev=e60457119a6e983131ecce0dad4f79528810dc8c#e60457119a6e983131ecce0dad4f79528810dc8c"
 dependencies = [
  "async-channel",
  "async-trait",

--- a/runners/s3-benchrunner-rust/Cargo.lock
+++ b/runners/s3-benchrunner-rust/Cargo.lock
@@ -240,7 +240,6 @@ dependencies = [
 [[package]]
 name = "aws-s3-transfer-manager"
 version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-s3-transfer-manager-rs.git?rev=dc7e9d2719b855416ec8f4c8d464bd1cb42381b2#dc7e9d2719b855416ec8f4c8d464bd1cb42381b2"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -259,6 +258,7 @@ dependencies = [
  "path-clean",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower 0.5.2",
  "tracing",
  "walkdir",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.12"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f6feb647fb5e0d5b50f0472c19a7db9462b74e2fec01bb0b44eedcc834e97"
+checksum = "c7b8a53819e42f10d0821f56da995e1470b199686a1809168db6ca485665f042"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1747,9 +1747,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
@@ -2020,9 +2020,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2708,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2725,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2768,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 
 # Swap which line is commented-out to use GitHub or local aws-s3-transfer-manager
-aws-s3-transfer-manager = { git = "https://github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "dc7e9d2719b855416ec8f4c8d464bd1cb42381b2" }
-# aws-s3-transfer-manager = { path = "../../../aws-s3-transfer-manager-rs/aws-s3-transfer-manager" }
+#aws-s3-transfer-manager = { git = "https://github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "dc7e9d2719b855416ec8f4c8d464bd1cb42381b2" }
+aws-s3-transfer-manager = { path = "../../../aws-s3-transfer-manager-rs/aws-s3-transfer-manager" }
 
 tracing-opentelemetry = "0.27"
 opentelemetry = { version = "0.26", features = ["trace"] }

--- a/runners/s3-benchrunner-rust/Cargo.toml
+++ b/runners/s3-benchrunner-rust/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 [dependencies]
 
 # Swap which line is commented-out to use GitHub or local aws-s3-transfer-manager
-#aws-s3-transfer-manager = { git = "https://github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "dc7e9d2719b855416ec8f4c8d464bd1cb42381b2" }
-aws-s3-transfer-manager = { path = "../../../aws-s3-transfer-manager-rs/aws-s3-transfer-manager" }
+aws-s3-transfer-manager = { git = "https://github.com/awslabs/aws-s3-transfer-manager-rs.git", rev = "e60457119a6e983131ecce0dad4f79528810dc8c" }
+#aws-s3-transfer-manager = { path = "../../../aws-s3-transfer-manager-rs/aws-s3-transfer-manager" }
 
 tracing-opentelemetry = "0.27"
 opentelemetry = { version = "0.26", features = ["trace"] }

--- a/runners/s3-benchrunner-rust/src/lib.rs
+++ b/runners/s3-benchrunner-rust/src/lib.rs
@@ -24,7 +24,7 @@ pub struct SkipBenchmarkError(String);
 #[macro_export]
 macro_rules! skip_benchmark {
     ($($args:tt)*) => {
-        Err(crate::SkipBenchmarkError(format!($($args)*)).into())
+        Err($crate::SkipBenchmarkError(format!($($args)*)).into())
     };
 }
 

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -4,9 +4,8 @@ use anyhow::Context;
 use async_trait::async_trait;
 use aws_s3_transfer_manager::{
     io::InputStream,
-    metrics::{unit::ByteUnit, Throughput},
     operation::upload::ChecksumStrategy,
-    types::{ConcurrencyMode, PartSize},
+    types::{ConcurrencyMode, PartSize, TargetThroughput},
 };
 use aws_sdk_s3::types::ChecksumAlgorithm;
 use bytes::{Buf, Bytes};
@@ -52,11 +51,9 @@ impl TransferManagerRunner {
         let random_data_for_upload = new_random_bytes(upload_data_size);
 
         let tm_config = aws_s3_transfer_manager::from_env()
-            // .concurrency(ConcurrencyMode::Explicit(total_concurrency))
             .concurrency(ConcurrencyMode::TargetThroughput(
-                Throughput::new_bytes_per_sec(
-                    (config.target_throughput_gigabits_per_sec
-                        * ByteUnit::Gigabit.as_bytes_u64() as f64) as u64,
+                TargetThroughput::new_gigabits_per_sec(
+                    config.target_throughput_gigabits_per_sec as u64,
                 ),
             ))
             .part_size(PartSize::Target(PART_SIZE))

--- a/runners/s3-benchrunner-rust/src/transfer_manager.rs
+++ b/runners/s3-benchrunner-rust/src/transfer_manager.rs
@@ -4,8 +4,9 @@ use anyhow::Context;
 use async_trait::async_trait;
 use aws_s3_transfer_manager::{
     io::InputStream,
+    metrics::{unit::ByteUnit, Throughput},
     operation::upload::ChecksumStrategy,
-    types::{ConcurrencySetting, PartSize},
+    types::{ConcurrencyMode, PartSize},
 };
 use aws_sdk_s3::types::ChecksumAlgorithm;
 use bytes::{Buf, Bytes};
@@ -33,9 +34,6 @@ struct Handle {
 
 impl TransferManagerRunner {
     pub async fn new(config: BenchmarkConfig) -> TransferManagerRunner {
-        // Blugh, the user shouldn't need to manually configure concurrency like this.
-        let total_concurrency = calculate_concurrency(config.target_throughput_gigabits_per_sec);
-
         // Create random buffer to upload
         let upload_data_size: usize = if config.workload.files_on_disk {
             0
@@ -54,7 +52,13 @@ impl TransferManagerRunner {
         let random_data_for_upload = new_random_bytes(upload_data_size);
 
         let tm_config = aws_s3_transfer_manager::from_env()
-            .concurrency(ConcurrencySetting::Explicit(total_concurrency))
+            // .concurrency(ConcurrencyMode::Explicit(total_concurrency))
+            .concurrency(ConcurrencyMode::TargetThroughput(
+                Throughput::new_bytes_per_sec(
+                    (config.target_throughput_gigabits_per_sec
+                        * ByteUnit::Gigabit.as_bytes_u64() as f64) as u64,
+                ),
+            ))
             .part_size(PartSize::Target(PART_SIZE))
             .load()
             .await;
@@ -261,15 +265,6 @@ impl RunBenchmark for TransferManagerRunner {
     fn config(&self) -> &BenchmarkConfig {
         &self.handle.config
     }
-}
-
-/// Calculate the best concurrency, given target throughput.
-/// This is based on aws-c-s3's math for determining max-http-connections, circa July 2024:
-/// https://github.com/awslabs/aws-c-s3/blob/94e3342c12833c519900516edd2e85c78dc1639d/source/s3_client.c#L57-L69
-/// These are magic numbers work well for large-object workloads.
-fn calculate_concurrency(target_throughput_gigabits_per_sec: f64) -> usize {
-    let concurrency = target_throughput_gigabits_per_sec * 2.5;
-    (concurrency as usize).max(10)
 }
 
 /// Find the common parent directory for all tasks.


### PR DESCRIPTION
*Issue #, if available:*
upstream: https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/95

*Description of changes:*
Replaces the hard coded concurrency number based on aws-c-s3 calculation with upstream changes that allow specifying a target throughput directly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
