### PR TITLE
Upgrade Benchmarks Canary Instance from c5n.18xlarge to c7gn.16xlarge

### DIFF
--- a/cdk/s3_benchmarks/__init__.py
+++ b/cdk/s3_benchmarks/__init__.py
@@ -41,6 +41,9 @@ def _add(instance_type: InstanceType):
 _add(InstanceType("c5n.18xlarge", vcpu=72, mem_GiB=192,
                   bandwidth_Gbps=100, quota_code=QUOTA_CODE_STANDARD_INSTANCES, storage_configuration=StorageConfiguration.EBS))
 
+_add(InstanceType("c7gn.16xlarge", vcpu=64, mem_GiB=128,
+                  bandwidth_Gbps=200, quota_code=QUOTA_CODE_STANDARD_INSTANCES, storage_configuration=StorageConfiguration.EBS))
+
 _add(InstanceType("m6idn.24xlarge", vcpu=96, mem_GiB=384,
                   bandwidth_Gbps=150, quota_code=QUOTA_CODE_STANDARD_INSTANCES, storage_configuration=StorageConfiguration.INSTANCE_STORAGE))
 

--- a/cdk/s3_benchmarks/s3_benchmarks_stack.py
+++ b/cdk/s3_benchmarks/s3_benchmarks_stack.py
@@ -398,7 +398,8 @@ class S3BenchmarksStack(Stack):
             self, f"PerInstanceDashboard-{storage_class}-{id_with_hyphens}",
             dashboard_name=f"S3Benchmarks-{storage_class}-{id_with_hyphens}",
         )
-        dashboard.apply_removal_policy(cdk.RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
+        dashboard.apply_removal_policy(
+            cdk.RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
 
         graph_per_workload = []
         for workload in DEFAULT_WORKLOADS:

--- a/cdk/s3_benchmarks/s3_benchmarks_stack.py
+++ b/cdk/s3_benchmarks/s3_benchmarks_stack.py
@@ -398,7 +398,7 @@ class S3BenchmarksStack(Stack):
             self, f"PerInstanceDashboard-{storage_class}-{id_with_hyphens}",
             dashboard_name=f"S3Benchmarks-{storage_class}-{id_with_hyphens}",
         )
-        dashboard.apply_removal_policy(cdk.RemovalPolicy.DESTROY)
+        dashboard.apply_removal_policy(cdk.RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
 
         graph_per_workload = []
         for workload in DEFAULT_WORKLOADS:

--- a/cdk/s3_benchmarks/s3_benchmarks_stack.py
+++ b/cdk/s3_benchmarks/s3_benchmarks_stack.py
@@ -33,7 +33,7 @@ class S3ClientProps:
 # - These defaults are what the Canary runs.
 # - (TODO) A dashboard is set up to view these instance-type/s3-client/workload combinations.
 DEFAULT_INSTANCE_TYPES = [
-    'c5n.18xlarge',
+    'c7gn.16xlarge',
 ]
 
 # The "default" set of S3 clients to benchmark.


### PR DESCRIPTION
*Description of changes:*
c5n.18xlarge instance was released over 6 years ago. Move to the latest and greatest c_n* instance (c7gn.16xlarge) which also has 200Gbps network bandwidth. This will give us more insights into how our runners behave on the best single NIC instance.
 
There are c8* instances but there is no networking-focused c8* instance as of today. c8g.48xlarge has only 50Gbps network bandwidth. So bump to c7gn.16xlarge instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
