### PR TITLE
Update C Runner to use a CLI Arguments Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ All runners have the same command line interface, and expect to be run from the
 ```sh
 cd FILES_DIR
 
-RUNNER_CMD S3_CLIENT WORKLOAD BUCKET REGION TARGET_THROUGHPUT [NETWORK_INTERFACES]
+RUNNER_CMD S3_CLIENT WORKLOAD BUCKET REGION TARGET_THROUGHPUT [--nic name1,name2]
 ```
 
 *   `S3_CLIENT`: ID of S3 client to use (See [table](#s3-clients) above)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ RUNNER_CMD S3_CLIENT WORKLOAD BUCKET REGION TARGET_THROUGHPUT [NETWORK_INTERFACE
         Floating point allowed. Enter the EC2 type's "Network Bandwidth (Gbps)"
         (e.g. "100.0" for [c5n.18xlarge](https://aws.amazon.com/ec2/instance-types/c5/))
 *   `NETWORK_INTERFACES`: **This is optionally supported for crt-c Runner**
-        A comma separated list of network interface names without any spaces like "ens5,ens6"
+        A comma separated list of network interface names without any spaces like "--nic ens5,ens6"
 
 Most runners should search for AWS credentials
 [something like this](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#configure-precedence).

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -242,7 +242,8 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
     if (cmdl[{"-h", "--help"}] || cmdl.pos_args().size() < 6)
     {
         fail(
-            std::string("usage: ") + argv[0] + " S3_CLIENT WORKLOAD BUCKET REGION TARGET_THROUGHPUT [--nic name1,name2]");
+            std::string("usage: ") + argv[0] +
+            " S3_CLIENT WORKLOAD BUCKET REGION TARGET_THROUGHPUT [--nic name1,name2]");
     }
 
     struct Args parsed_args;

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -221,14 +221,14 @@ void printAllStats(uint64_t bytesPerRun, const vector<double> &durations)
 
 struct Args
 {
-    std::string s3ClientId;
-    std::string workload;
-    std::string bucket;
-    std::string region;
+    string s3ClientId;
+    string workload;
+    string bucket;
+    string region;
     double targetThroughputGbps;
 
     // Optional arguments
-    std::string network_interface_names = "";
+    string network_interface_names = "";
 };
 
 int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &createRunnerFromName)
@@ -252,7 +252,7 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
     parsed_args.workload = cmdl[2];
     parsed_args.bucket = cmdl[3];
     parsed_args.region = cmdl[4];
-    parsed_args.targetThroughputGbps = std::stod(cmdl[5]);
+    parsed_args.targetThroughputGbps = stod(cmdl[5]);
 
     // Parse optional named parameters
     cmdl("nic") >> parsed_args.network_interface_names;

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -9,7 +9,7 @@
 
 #include <aws/common/system_resource_util.h>
 
-#include "argh.h"
+#include <argh.h>
 #include <nlohmann/json.hpp>
 
 using namespace std;

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -219,12 +219,13 @@ void printAllStats(uint64_t bytesPerRun, const vector<double> &durations)
     printf("Peak RSS:%f MiB\n", (double)mu.maxrss / 1024.0);
 }
 
-struct Args {
+struct Args
+{
     std::string s3ClientId;
     std::string workload;
     std::string bucket;
     std::string region;
-    double targetThroughputGbps;  
+    double targetThroughputGbps;
 
     // Optional arguments
     std::string network_interface_names = "";
@@ -235,15 +236,17 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
     // START Argument Parsing
     argh::parser cmdl;
     // pre-register optional options to support --param_name param_value syntax
-    cmdl.add_params({ "--nic" });
+    cmdl.add_params({"--nic"});
     cmdl.parse(argc, argv);
 
-    if (cmdl[{"-h", "--help"}] || cmdl.pos_args().size() < 6) {
-        fail(std::string("usage: ") + argv[0] + " S3_CLIENT WORKLOAD BUCKET REGION TARGET_THROUGHPUT --nic name1,name2");
+    if (cmdl[{"-h", "--help"}] || cmdl.pos_args().size() < 6)
+    {
+        fail(
+            std::string("usage: ") + argv[0] + " S3_CLIENT WORKLOAD BUCKET REGION TARGET_THROUGHPUT --nic name1,name2");
     }
 
     struct Args parsed_args;
-    
+
     // Parse required positional parameters
     parsed_args.s3ClientId = cmdl[1];
     parsed_args.workload = cmdl[2];
@@ -255,7 +258,12 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
     cmdl("nic") >> parsed_args.network_interface_names;
     // END argument parsing
 
-    auto config = BenchmarkConfig(parsed_args.workload, parsed_args.bucket, parsed_args.region, parsed_args.targetThroughputGbps, parsed_args.network_interface_names);
+    auto config = BenchmarkConfig(
+        parsed_args.workload,
+        parsed_args.bucket,
+        parsed_args.region,
+        parsed_args.targetThroughputGbps,
+        parsed_args.network_interface_names);
     unique_ptr<BenchmarkRunner> benchmark = createRunnerFromName(parsed_args.s3ClientId, config);
     uint64_t bytesPerRun = config.bytesPerRun();
 

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -235,7 +235,7 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
 {
     // START Argument Parsing
     argh::parser cmdl;
-    // pre-register optional options to support --param_name param_value syntax
+    // pre-register optional named arguments to support --param_name param_value syntax
     cmdl.add_params({"--nic"});
     cmdl.parse(argc, argv);
 
@@ -254,7 +254,7 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
     parsed_args.region = cmdl[4];
     parsed_args.targetThroughputGbps = stod(cmdl[5]);
 
-    // Parse optional named parameters
+    // Parse optional named arguments
     cmdl("nic") >> parsed_args.network_interface_names;
     // END argument parsing
 

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -242,7 +242,7 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
     if (cmdl[{"-h", "--help"}] || cmdl.pos_args().size() < 6)
     {
         fail(
-            std::string("usage: ") + argv[0] + " S3_CLIENT WORKLOAD BUCKET REGION TARGET_THROUGHPUT --nic name1,name2");
+            std::string("usage: ") + argv[0] + " S3_CLIENT WORKLOAD BUCKET REGION TARGET_THROUGHPUT [--nic name1,name2]");
     }
 
     struct Args parsed_args;

--- a/runners/s3-benchrunner-c/BenchmarkRunner.h
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.h
@@ -52,7 +52,6 @@ struct BenchmarkConfig
     uint64_t bytesPerRun() const;
 };
 
-
 // struct for a task in the benchmark's JSON config
 struct TaskConfig
 {

--- a/runners/s3-benchrunner-c/BenchmarkRunner.h
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.h
@@ -26,17 +26,6 @@ double bytesToGigabit(uint64_t bytes);
 // use standardized part-size across all benchmarks
 #define PART_SIZE (8 * 1024 * 1024)
 
-struct Args {
-    std::string s3ClientId;
-    std::string workload;
-    std::string bucket;
-    std::string region;
-    double targetThroughputGbps;  
-
-    // Optional arguments
-    std::string network_interface_names = "";
-};
-
 // struct for a benchmark config, loaded from JSON
 struct BenchmarkConfig
 {

--- a/runners/s3-benchrunner-c/BenchmarkRunner.h
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.h
@@ -26,6 +26,17 @@ double bytesToGigabit(uint64_t bytes);
 // use standardized part-size across all benchmarks
 #define PART_SIZE (8 * 1024 * 1024)
 
+struct Args {
+    std::string s3ClientId;
+    std::string workload;
+    std::string bucket;
+    std::string region;
+    double targetThroughputGbps;  
+
+    // Optional arguments
+    std::string network_interface_names = "";
+};
+
 // struct for a benchmark config, loaded from JSON
 struct BenchmarkConfig
 {
@@ -51,6 +62,7 @@ struct BenchmarkConfig
 
     uint64_t bytesPerRun() const;
 };
+
 
 // struct for a task in the benchmark's JSON config
 struct TaskConfig

--- a/runners/s3-benchrunner-c/CMakeLists.txt
+++ b/runners/s3-benchrunner-c/CMakeLists.txt
@@ -24,11 +24,7 @@ FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download
 FetchContent_MakeAvailable(json)
 
 # CLI parser
-FetchContent_Declare(
-    argh_parser
-    GIT_REPOSITORY https://github.com/adishavit/argh
-    GIT_TAG v1.3.2
-)
+FetchContent_Declare(argh_parser URL https://github.com/adishavit/argh/archive/refs/tags/v1.3.2.tar.gz)
 FetchContent_MakeAvailable(argh_parser)
 
 find_package(aws-c-s3 REQUIRED)

--- a/runners/s3-benchrunner-c/CMakeLists.txt
+++ b/runners/s3-benchrunner-c/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.22)
 cmake_policy(VERSION 3.22...3.24)
 project(s3-benchrunner-c CXX)
 
-message(STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
-message(STATUS "C++ compiler flags: ${CMAKE_CXX_FLAGS}")
-
 add_executable(${PROJECT_NAME}
     BenchmarkRunner.cpp
     CRunner.cpp)
@@ -16,7 +13,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 20)
 
 if(NOT MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE "-fno-rtti")
+    target_compile_options(${PROJECT_NAME} PRIVATE "-fno-exceptions;-fno-rtti")
 endif()
 
 # dependencies
@@ -26,18 +23,15 @@ include(FetchContent)
 FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
 FetchContent_MakeAvailable(json)
 
-# using CLI11 for CLI argument parsing
-
-
+# CLI parser
 FetchContent_Declare(
-    cli11_proj
+    argh_parser
     QUIET
-    GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
-    GIT_TAG v2.5.0
+    GIT_REPOSITORY https://github.com/adishavit/argh
+    GIT_TAG v1.3.2
 )
-FetchContent_MakeAvailable(cli11_proj)
+FetchContent_MakeAvailable(argh_parser)
 
 find_package(aws-c-s3 REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-s3 nlohmann_json)
-target_link_libraries(${PROJECT_NAME} PRIVATE CLI11::CLI11)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-s3 nlohmann_json argh)

--- a/runners/s3-benchrunner-c/CMakeLists.txt
+++ b/runners/s3-benchrunner-c/CMakeLists.txt
@@ -26,7 +26,6 @@ FetchContent_MakeAvailable(json)
 # CLI parser
 FetchContent_Declare(
     argh_parser
-    QUIET
     GIT_REPOSITORY https://github.com/adishavit/argh
     GIT_TAG v1.3.2
 )

--- a/runners/s3-benchrunner-c/CMakeLists.txt
+++ b/runners/s3-benchrunner-c/CMakeLists.txt
@@ -33,4 +33,4 @@ FetchContent_MakeAvailable(argh_parser)
 
 find_package(aws-c-s3 REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-s3 nlohmann_json argh)
+target_link_libraries(${PROJECT_NAME} AWS::aws-c-s3 nlohmann_json argh)

--- a/runners/s3-benchrunner-c/CMakeLists.txt
+++ b/runners/s3-benchrunner-c/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.22)
 cmake_policy(VERSION 3.22...3.24)
 project(s3-benchrunner-c CXX)
 
+message(STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
+message(STATUS "C++ compiler flags: ${CMAKE_CXX_FLAGS}")
+
 add_executable(${PROJECT_NAME}
     BenchmarkRunner.cpp
     CRunner.cpp)
@@ -13,7 +16,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 20)
 
 if(NOT MSVC)
-    target_compile_options(${PROJECT_NAME} PRIVATE "-fno-exceptions;-fno-rtti")
+    target_compile_options(${PROJECT_NAME} PRIVATE "-fno-rtti")
 endif()
 
 # dependencies
@@ -23,6 +26,18 @@ include(FetchContent)
 FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
 FetchContent_MakeAvailable(json)
 
+# using CLI11 for CLI argument parsing
+
+
+FetchContent_Declare(
+    cli11_proj
+    QUIET
+    GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
+    GIT_TAG v2.5.0
+)
+FetchContent_MakeAvailable(cli11_proj)
+
 find_package(aws-c-s3 REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} AWS::aws-c-s3 nlohmann_json)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-c-s3 nlohmann_json)
+target_link_libraries(${PROJECT_NAME} PRIVATE CLI11::CLI11)

--- a/runners/s3-benchrunner-cpp/CMakeLists.txt
+++ b/runners/s3-benchrunner-cpp/CMakeLists.txt
@@ -33,10 +33,18 @@ include(FetchContent)
 FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
 FetchContent_MakeAvailable(json)
 
+# CLI parser
+FetchContent_Declare(
+    argh_parser
+    GIT_REPOSITORY https://github.com/adishavit/argh
+    GIT_TAG v1.3.2
+)
+FetchContent_MakeAvailable(argh_parser)
+
 # aws-sdk-cpp fails to link on MacOS unless we manually add zlib here:
 # https://github.com/aws/aws-sdk-cpp/issues/2635#issuecomment-1708483628
 find_package(ZLIB REQUIRED)
 
 find_package(AWSSDK REQUIRED COMPONENTS s3-crt transfer)
 
-target_link_libraries(${PROJECT_NAME} nlohmann_json aws-cpp-sdk-s3-crt aws-cpp-sdk-transfer)
+target_link_libraries(${PROJECT_NAME} nlohmann_json argh aws-cpp-sdk-s3-crt aws-cpp-sdk-transfer)

--- a/runners/s3-benchrunner-cpp/CMakeLists.txt
+++ b/runners/s3-benchrunner-cpp/CMakeLists.txt
@@ -34,11 +34,7 @@ FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download
 FetchContent_MakeAvailable(json)
 
 # CLI parser
-FetchContent_Declare(
-    argh_parser
-    GIT_REPOSITORY https://github.com/adishavit/argh
-    GIT_TAG v1.3.2
-)
+FetchContent_Declare(argh_parser URL https://github.com/adishavit/argh/archive/refs/tags/v1.3.2.tar.gz)
 FetchContent_MakeAvailable(argh_parser)
 
 # aws-sdk-cpp fails to link on MacOS unless we manually add zlib here:


### PR DESCRIPTION
*Description of changes:*
- Follow up to #92
- This PR updates the CLI argument parsing for C runners to use https://github.com/adishavit/argh so that we can easily support multiple optional arguments. I picked argh for the following reasons:
    - Minimalist
    - Doesn't require us to enable exceptions like CLI11. C++ SDK doesn't use exceptions. While enabling exceptions won't harm in the success case, in the failure cases it can lead to weird issues like something used by cpp-sdk raising an exception but they will never catch/check it.
    - Easy to install with cmake


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
