### PR TITLE
Fix C Benchmark Runner for GCC < 13

### DIFF
--- a/runners/s3-benchrunner-c/CRunner.cpp
+++ b/runners/s3-benchrunner-c/CRunner.cpp
@@ -255,10 +255,12 @@ void CRunner::run(size_t runNumber)
     FILE *telemetryFile = NULL;
     if (!telemetryFileBasePath.empty())
     {
-        stringstream filePath; 
-        filePath << telemetryFileBasePath << "/"; 
-        // pad the numbers like 01,02 instead 1,2 for asciibetically sorting. 
-        filePath << setfill('0') << setw(2) << runNumber; filePath << ".csv"; telemetryFile = fopen(filePath.str().c_str(), "w");
+        stringstream filePath;
+        filePath << telemetryFileBasePath << "/";
+        // pad the numbers like 01,02 instead 1,2 for asciibetically sorting.
+        filePath << setfill('0') << setw(2) << runNumber;
+        filePath << ".csv";
+        telemetryFile = fopen(filePath.str().c_str(), "w");
         telemetryFile = fopen(filePath.str().c_str(), "w");
     }
     // kick off all tasks

--- a/runners/s3-benchrunner-c/CRunner.cpp
+++ b/runners/s3-benchrunner-c/CRunner.cpp
@@ -12,10 +12,10 @@
 #include <aws/io/tls_channel_handler.h>
 #include <aws/s3/s3_client.h>
 
-#include <format>
 #include <future>
 #include <list>
 #include <sstream>
+#include <iomanip>
 
 using namespace std;
 
@@ -256,7 +256,9 @@ void CRunner::run(size_t runNumber)
     if (!telemetryFileBasePath.empty())
     {
         // pad the numbers like 01,02 instead 1,2 for asciibetically sorting.
-        string file_path = telemetryFileBasePath + "/" + std::format("{:02d}", runNumber) + ".csv";
+        stringstream ss;
+        ss << setfill('0') << setw(2) << runNumber;
+        string file_path = telemetryFileBasePath + "/" + ss.str() + ".csv";
         telemetryFile = fopen(file_path.c_str(), "w");
     }
     // kick off all tasks

--- a/runners/s3-benchrunner-c/CRunner.cpp
+++ b/runners/s3-benchrunner-c/CRunner.cpp
@@ -255,11 +255,11 @@ void CRunner::run(size_t runNumber)
     FILE *telemetryFile = NULL;
     if (!telemetryFileBasePath.empty())
     {
-        // pad the numbers like 01,02 instead 1,2 for asciibetically sorting.
-        stringstream ss;
-        ss << setfill('0') << setw(2) << runNumber;
-        string file_path = telemetryFileBasePath + "/" + ss.str() + ".csv";
-        telemetryFile = fopen(file_path.c_str(), "w");
+        stringstream filePath; 
+        filePath << telemetryFileBasePath << "/"; 
+        // pad the numbers like 01,02 instead 1,2 for asciibetically sorting. 
+        filePath << setfill('0') << setw(2) << runNumber; filePath << ".csv"; telemetryFile = fopen(filePath.str().c_str(), "w");
+        telemetryFile = fopen(filePath.str().c_str(), "w");
     }
     // kick off all tasks
     list<Task> runningTasks;

--- a/runners/s3-benchrunner-c/CRunner.cpp
+++ b/runners/s3-benchrunner-c/CRunner.cpp
@@ -13,9 +13,9 @@
 #include <aws/s3/s3_client.h>
 
 #include <future>
+#include <iomanip>
 #include <list>
 #include <sstream>
-#include <iomanip>
 
 using namespace std;
 


### PR DESCRIPTION
*Description of changes:*
Yesterday, after merging #96, our benchmark canary failed with the following error:

```
/workdir/s3-benchmarks-lgow5c_n> cmake --build /workdir/s3-benchmarks-lgow5c_n/build/c/s3-benchrunner-c-build --parallel 64 --target install
[ 33%] Building CXX object CMakeFiles/s3-benchrunner-c.dir/BenchmarkRunner.cpp.o
[ 66%] Building CXX object CMakeFiles/s3-benchrunner-c.dir/CRunner.cpp.o
/workdir/s3-benchmarks-lgow5c_n/aws-crt-s3-benchmarks/runners/s3-benchrunner-c/CRunner.cpp:15:10: fatal error: format: No such file or directory
   15 | #include <format>
      |          ^~~~~~~~
compilation terminated.
```
The reason for failure is that even though std::format was added in C++20, gcc didn't have full support until gcc-13 (https://en.cppreference.com/w/cpp/compiler_support). Our CI and my local environment were using gcc-13 but our benchmark canary uses gcc-11 so that's why it only failed in the canary. This PR removes the usage of `std::format`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
