### PR TITLE
generate small buffer to fill the whole one

### DIFF
--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -156,7 +156,7 @@ BenchmarkRunner::BenchmarkRunner(const BenchmarkConfig &config) : config(config)
 
         // We don't want any parts to be identical.
         // Use something that won't fall on a part boundary as we copy it.
-        const size_t randomBlockSize = std::min(31415926, maxUploadSize); // approx 30MiB, digits of pi
+        const size_t randomBlockSize = std::min((size_t)31415926, maxUploadSize); // approx 30MiB, digits of pi
         std::vector<uint8_t> randomBlock(randomBlockSize);
         independent_bits_engine<default_random_engine, CHAR_BIT, unsigned char> randEngine;
         generate(randomBlock.begin(), randomBlock.end(), randEngine);

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -156,7 +156,7 @@ BenchmarkRunner::BenchmarkRunner(const BenchmarkConfig &config) : config(config)
 
         // We don't want any parts to be identical.
         // Use something that won't fall on a part boundary as we copy it.
-        const size_t randomBlockSize = min(31415926, maxUploadSize); // approx 30MiB, digits of pi
+        const size_t randomBlockSize = std::min(31415926, maxUploadSize); // approx 30MiB, digits of pi
         std::vector<uint8_t> randomBlock(randomBlockSize);
         independent_bits_engine<default_random_engine, CHAR_BIT, unsigned char> randEngine;
         generate(randomBlock.begin(), randomBlock.end(), randEngine);

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -162,14 +162,14 @@ BenchmarkRunner::BenchmarkRunner(const BenchmarkConfig &config) : config(config)
 
         // Fill the buffer by repeating the random block
         size_t bytesWritten = 0;
-        while (bytesWritten < maxUploadSize) {
+        while (bytesWritten < maxUploadSize)
+        {
             // Calculate how many bytes to copy in this iteration
             size_t bytesToCopy = std::min(randomBlockSize, maxUploadSize - bytesWritten);
 
             // Copy the bytes from the random block to the target buffer
-            std::copy(randomBlock.begin(),
-                    randomBlock.begin() + bytesToCopy,
-                    randomDataForUpload.begin() + bytesWritten);
+            std::copy(
+                randomBlock.begin(), randomBlock.begin() + bytesToCopy, randomDataForUpload.begin() + bytesWritten);
 
             bytesWritten += bytesToCopy;
         }

--- a/runners/s3-benchrunner-c/CRunner.cpp
+++ b/runners/s3-benchrunner-c/CRunner.cpp
@@ -353,6 +353,8 @@ Task::Task(CRunner &runner, size_t taskI, FILE *telemetryFile)
             checksumConfig.checksum_algorithm = AWS_SCA_SHA1;
         else if (runner.config.checksum == "SHA256")
             checksumConfig.checksum_algorithm = AWS_SCA_SHA256;
+        else if (runner.config.checksum == "CRC64")
+            checksumConfig.checksum_algorithm = AWS_SCA_CRC64NVME;
         else
             fail(string("Unknown checksum: ") + runner.config.checksum);
         checksumConfig.location = AWS_SCL_HEADER;

--- a/runners/s3-benchrunner-c/CRunner.cpp
+++ b/runners/s3-benchrunner-c/CRunner.cpp
@@ -353,8 +353,6 @@ Task::Task(CRunner &runner, size_t taskI, FILE *telemetryFile)
             checksumConfig.checksum_algorithm = AWS_SCA_SHA1;
         else if (runner.config.checksum == "SHA256")
             checksumConfig.checksum_algorithm = AWS_SCA_SHA256;
-        else if (runner.config.checksum == "CRC64")
-            checksumConfig.checksum_algorithm = AWS_SCA_CRC64NVME;
         else
             fail(string("Unknown checksum: ") + runner.config.checksum);
         checksumConfig.location = AWS_SCL_HEADER;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- generate smaller buffer instead of the total size of random buffer. So that we don't need wait 5 mins for generating the total 30GB random buffer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
