### PR TITLE
Fix CDK deployment on windows

### DIFF
--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -11,7 +11,8 @@
       "source.bat",
       "**/__init__.py",
       "**/__pycache__",
-      "tests"
+      "tests",
+      "cdk.out"
     ]
   },
   "context": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Adds `cdk.out` to list of folders to exclude when doing deploy. Without this change, it was doing an infinite creation of the directories on windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
