### PR TITLE
Revert dashboard removal policy to delete

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -51,6 +51,10 @@ CDK Python project that sets up infrastructure to automatically run the S3 bench
     ```sh
     cdk deploy -c settings=<myname.settings.json>
     ```
+   Depending upon your host machine architecture and Docker image architecture, you might get an error like "/bin/sh: exec format error". Install binfmt to fix it.
+   ```sh
+   docker run --privileged --rm tonistiigi/binfmt --install all
+   ```
 
 ## Running benchmarks
 

--- a/cdk/s3_benchmarks/s3_benchmarks_stack.py
+++ b/cdk/s3_benchmarks/s3_benchmarks_stack.py
@@ -398,8 +398,7 @@ class S3BenchmarksStack(Stack):
             self, f"PerInstanceDashboard-{storage_class}-{id_with_hyphens}",
             dashboard_name=f"S3Benchmarks-{storage_class}-{id_with_hyphens}",
         )
-        dashboard.apply_removal_policy(
-            cdk.RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE)
+        dashboard.apply_removal_policy(cdk.RemovalPolicy.DESTROY)
 
         graph_per_workload = []
         for workload in DEFAULT_WORKLOADS:


### PR DESCRIPTION
*Description of changes:*
- We can't deploy the stack as the dashboard already exists. It's fine to delete the dashboard and create it again since the underlying data is not deleted.
- Update README with instructions to install `binfmt` since now we build x64 and arm64 Docker containers which fail without emulation layer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
