### PR TITLE
aws-c runner pre-run cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.9' # default version on Amazon Linux 2023
+        python-version: '3.10' # boto3 develop branch requires >=3.10
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.9' # default version on Amazon Linux 2023
+        python-version: '3.10' # boto3 develop branch requires >=3.10
 
     - run: python -m pip install -r scripts/requirements.txt
 

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -1,6 +1,7 @@
 #include "BenchmarkRunner.h"
 
 #include <algorithm>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <random>
@@ -182,6 +183,22 @@ BenchmarkRunner::BenchmarkRunner(const BenchmarkConfig &config) : config(config)
 
 BenchmarkRunner::~BenchmarkRunner() = default;
 
+void BenchmarkRunner::prepareRun()
+{
+    // Delete downloaded files before each run, so the next run starts fresh.
+    for (auto &&task : config.tasks)
+    {
+        if (task.action == "download" && config.filesOnDisk)
+        {
+            filesystem::path filePath(task.key);
+            if (filesystem::exists(filePath))
+            {
+                filesystem::remove(filePath);
+            }
+        }
+    }
+}
+
 // If telemetry is enabled, output stats for each run to ./telemetry/<workload_name>/<current_date_time>/stats.txt
 FILE *statsFile = NULL;
 
@@ -362,6 +379,8 @@ int benchmarkRunnerMain(int argc, char *argv[], const CreateRunnerFromNameFn &cr
     auto appStart = high_resolution_clock::now();
     for (int runNumber = 1; runNumber <= config.maxRepeatCount; ++runNumber)
     {
+        benchmark->prepareRun();
+
         auto runStart = high_resolution_clock::now();
 
         benchmark->run(runNumber);

--- a/runners/s3-benchrunner-c/BenchmarkRunner.h
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.h
@@ -79,6 +79,9 @@ class BenchmarkRunner
     BenchmarkRunner(const BenchmarkRunner &) = delete;
     BenchmarkRunner &operator=(const BenchmarkRunner &) = delete;
 
+    // Preparation work between runs (e.g. delete downloaded files so next run starts fresh)
+    virtual void prepareRun();
+
     // A benchmark can be run repeatedly
     virtual void run(size_t runNumber) = 0;
 };


### PR DESCRIPTION
Noticed crt-java runner was outperforming crt-c runner dramatically. It seems to do with java clearing out previous run files before starting the next run while c did not.

Added clean up before starting a benchmark run via prepare_run().

pre-cleanup the crt-c-download-256KiB-10_000x was downloading a mean of 1.22Gb/s and 17.3 seconds. After the cleanup we are seeing 24.9Gb/s and 0.95 seconds.

Updated Python to 3.10 in CI jobs because Boto3 develop branch has raised its minimum version of Python support

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
