### PR TITLE
Metrics collection updates

### DIFF
--- a/scripts/install-tools-AL2023.py
+++ b/scripts/install-tools-AL2023.py
@@ -18,6 +18,8 @@ if not shutil.which('sudo'):
 run(['sudo', 'dnf', 'install', '-y',
      'git',
      'python3-pip',  # for installing python packages
+     'python3.11',  # boto3 dropped Python 3.9 support; AL2023 has 3.11 available
+     'python3.11-pip',
      'cmake',  # for building aws-c-***
      'gcc',  # for building aws-c-***
      'gcc-c++',  # for building s3-benchrunner-c
@@ -27,6 +29,7 @@ run(['sudo', 'dnf', 'install', '-y',
      'maven',  # for building s3-benchrunner-java
      'java-17-amazon-corretto-devel',  # for building s3-benchrunner-java
      'python3-devel',  # for building aws-crt-python
+     'python3.11-devel',  # for building aws-crt-python with 3.11
      'go',  # for building s5cmd
      ])
 

--- a/scripts/prep-build-run-benchmarks.py
+++ b/scripts/prep-build-run-benchmarks.py
@@ -65,40 +65,65 @@ if __name__ == '__main__':
 
     # track which runners we've already built
     runner_lang_to_cmd = {}
+    # track languages that failed to build, so we skip their clients
+    failed_langs = set()
+    failed_clients = []
 
     for s3_client_id in args.s3_clients:
         runner = S3_CLIENTS[s3_client_id].runner
 
-        # build runner for this language (if necessary)
-        # and get cmd args to run it
-        if not runner.lang in runner_lang_to_cmd:
-            print_banner(f'BUILD RUNNER: {runner.lang}')
-            runner_cmd_list = utils.build.build_runner(
-                runner.lang, build_dir, args.branch)
-            runner_cmd_str = subprocess.list2cmdline(runner_cmd_list)
-            runner_lang_to_cmd[runner.lang] = runner_cmd_str
-
-        for bucket in args.buckets:
+        # skip clients whose language already failed to build
+        if runner.lang in failed_langs:
             print_banner(
-                f'RUN BENCHMARKS: {get_bucket_storage_class(bucket)} - {s3_client_id}')
-            run_cmd = [
-                sys.executable, str(SCRIPTS_DIR/'run-benchmarks.py'),
-                '--runner-cmd', runner_lang_to_cmd[runner.lang],
-                '--s3-client', s3_client_id,
-                '--bucket', bucket,
-                '--region', args.region,
-                '--throughput', str(args.throughput),
-                '--files-dir', str(files_dir),
-                '--workloads', *[str(x) for x in workloads],
-            ]
-            if args.report_metrics:
-                run_cmd += ['--report-metrics']
+                f'SKIPPING: {s3_client_id} (build for {runner.lang} failed earlier)')
+            failed_clients.append(s3_client_id)
+            continue
 
-                if args.metrics_instance_type:
-                    run_cmd += ['--metrics-instance-type',
-                                args.metrics_instance_type]
+        try:
+            # build runner for this language (if necessary)
+            # and get cmd args to run it
+            if runner.lang not in runner_lang_to_cmd:
+                print_banner(f'BUILD RUNNER: {runner.lang}')
+                runner_cmd_list = utils.build.build_runner(
+                    runner.lang, build_dir, args.branch)
+                runner_cmd_str = subprocess.list2cmdline(runner_cmd_list)
+                runner_lang_to_cmd[runner.lang] = runner_cmd_str
 
-                # if default branch was used, report "main"
-                run_cmd += ['--metrics-branch', args.branch or "main"]
+            for bucket in args.buckets:
+                print_banner(
+                    f'RUN BENCHMARKS: {get_bucket_storage_class(bucket)} - {s3_client_id}')
+                run_cmd = [
+                    sys.executable, str(SCRIPTS_DIR/'run-benchmarks.py'),
+                    '--runner-cmd', runner_lang_to_cmd[runner.lang],
+                    '--s3-client', s3_client_id,
+                    '--bucket', bucket,
+                    '--region', args.region,
+                    '--throughput', str(args.throughput),
+                    '--files-dir', str(files_dir),
+                    '--workloads', *[str(x) for x in workloads],
+                ]
+                if args.report_metrics:
+                    run_cmd += ['--report-metrics']
 
-            run(run_cmd)
+                    if args.metrics_instance_type:
+                        run_cmd += ['--metrics-instance-type',
+                                    args.metrics_instance_type]
+
+                    # if default branch was used, report "main"
+                    run_cmd += ['--metrics-branch', args.branch or "main"]
+
+                run(run_cmd)
+        except subprocess.CalledProcessError as e:
+            print(f'\n*** FAILED: {s3_client_id} ({runner.lang}): {e}')
+            failed_clients.append(s3_client_id)
+            # if the build itself failed, mark the language so we skip
+            # other clients that share the same runner
+            if runner.lang not in runner_lang_to_cmd:
+                failed_langs.add(runner.lang)
+            continue
+
+    if failed_clients:
+        print_banner('SUMMARY: FAILED CLIENTS')
+        for client_id in failed_clients:
+            print(f'  - {client_id}')
+        sys.exit(1)

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -295,23 +295,23 @@ def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
                    preferred_branch=branch)
     os.chdir(str(sdk_src))
     _run_mvn_with_retry(['mvn', 'clean', 'install',
-         '--projects', ':s3-transfer-manager,:s3,:bom-internal,:bom',
-         '--activate-profiles', 'quick',
-         '--also-make',
-         # use locally installed version of aws-crt-java
-         '-Dawscrt.version=1.0.0-SNAPSHOT',
-         ])
+                         '--projects', ':s3-transfer-manager,:s3,:bom-internal,:bom',
+                         '--activate-profiles', 'quick',
+                         '--also-make',
+                         # use locally installed version of aws-crt-java
+                         '-Dawscrt.version=1.0.0-SNAPSHOT',
+                         ])
 
     # Build runner
     runner_src = RUNNERS['java'].dir
     os.chdir(str(runner_src))
     _run_mvn_with_retry(['mvn',
-         'clean',
-         # package along with dependencies in executable uber-java
-         'package',
-         # use locally installed version of aws-crt-java
-         '-Dawscrt.version=1.0.0-SNAPSHOT',
-         ])
+                         'clean',
+                         # package along with dependencies in executable uber-java
+                         'package',
+                         # use locally installed version of aws-crt-java
+                         '-Dawscrt.version=1.0.0-SNAPSHOT',
+                         ])
 
     # return command for running the jar
     jar_path = runner_src/'target/s3-benchrunner-java-1.0-SNAPSHOT.jar'

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -176,8 +176,90 @@ def _build_python(work_dir: Path, branch: Optional[str]) -> list[str]:
     return [venv_python, str(main_path)]
 
 
+def _setup_maven_codeartifact():
+    """Configure Maven to use CodeArtifact as a caching proxy for Maven Central.
+
+    Maven Central rate-limits/blocks AWS EC2 IP ranges with HTTP 403,
+    causing intermittent Java build failures in Batch jobs. Since each Batch job
+    runs in a fresh container with no .m2 cache, every run must download all
+    plugins and dependencies from scratch.
+
+    CodeArtifact acts as a transparent caching proxy. The first request
+    for any artifact is fetched from Maven Central and cached. All subsequent
+    requests (from any job, any day) are served from the cache. Since this is
+    AWS-to-AWS traffic within the same account, there's no rate limiting.
+
+    If anything fails Maven will fall back to hitting Central directly.
+    """
+    import subprocess as sp
+
+    domain = 's3-benchmarks'
+    repo = 'maven-cache'
+    region = 'us-west-2'
+
+    try:
+        # Discover the AWS account ID from the Batch job's IAM role.
+        # This avoids hardcoding the account ID in a public repo.
+        owner = sp.check_output([
+            'aws', 'sts', 'get-caller-identity',
+            '--query', 'Account', '--output', 'text'
+        ]).decode().strip()
+        # Get a 12-hour auth token for CodeArtifact.
+        # This uses the Batch job's IAM role (no explicit credentials needed).
+        token = sp.check_output([
+            'aws', 'codeartifact', 'get-authorization-token',
+            '--domain', domain, '--domain-owner', owner,
+            '--query', 'authorizationToken', '--output', 'text',
+            '--region', region
+        ]).decode().strip()
+
+        # Get the HTTPS endpoint URL for the maven-cache repository.
+        # This is what Maven will use instead of https://repo.maven.apache.org/maven2
+        endpoint = sp.check_output([
+            'aws', 'codeartifact', 'get-repository-endpoint',
+            '--domain', domain, '--domain-owner', owner,
+            '--repository', repo, '--format', 'maven',
+            '--query', 'repositoryEndpoint', '--output', 'text',
+            '--region', region
+        ]).decode().strip()
+    except (sp.CalledProcessError, FileNotFoundError):
+        # CalledProcessError: AWS CLI failed (missing permissions, no CodeArtifact)
+        # FileNotFoundError: AWS CLI not installed (local dev without AWS CLI)
+        print("WARNING: Could not configure CodeArtifact mirror, "
+              "falling back to Maven Central directly")
+        return
+
+    # Write Maven settings.xml that redirects all "central" repo requests
+    # to our CodeArtifact endpoint. The <mirrorOf>central</mirrorOf> directive
+    # intercepts any request that would go to Maven Central.
+    m2_dir = Path.home() / '.m2'
+    m2_dir.mkdir(exist_ok=True)
+    (m2_dir / 'settings.xml').write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<settings>\n'
+        '  <servers>\n'
+        '    <server>\n'
+        '      <id>codeartifact</id>\n'
+        '      <username>aws</username>\n'
+        f'      <password>{token}</password>\n'
+        '    </server>\n'
+        '  </servers>\n'
+        '  <mirrors>\n'
+        '    <mirror>\n'
+        '      <id>codeartifact</id>\n'
+        '      <name>CodeArtifact Maven Central Cache</name>\n'
+        f'      <url>{endpoint}</url>\n'
+        '      <mirrorOf>central</mirrorOf>\n'
+        '    </mirror>\n'
+        '  </mirrors>\n'
+        '</settings>\n')
+    print(f"Configured Maven to use CodeArtifact mirror: {endpoint}")
+
+
 def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
     """build s3-benchrunner-java"""
+
+    _setup_maven_codeartifact()
 
     # fetch latest aws-crt-java and install 1.0.0-SNAPSHOT
     awscrt_src = work_dir/'aws-crt-java'

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -201,7 +201,7 @@ def _setup_maven_codeartifact():
     region = 'us-west-2'
 
     try:
-        import boto3
+        import boto3  # type: ignore[import-untyped]
 
         # Discover the AWS account ID from the Batch job's IAM role.
         sts = boto3.client('sts', region_name=region)

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -192,7 +192,6 @@ def _setup_maven_codeartifact():
 
     If anything fails Maven will fall back to hitting Central directly.
     """
-    import subprocess as sp
 
     domain = 's3-benchmarks'
     repo = 'maven-cache'
@@ -201,33 +200,37 @@ def _setup_maven_codeartifact():
     try:
         # Discover the AWS account ID from the Batch job's IAM role.
         # This avoids hardcoding the account ID in a public repo.
-        owner = sp.check_output([
+        owner = subprocess.check_output([
             'aws', 'sts', 'get-caller-identity',
             '--query', 'Account', '--output', 'text'
-        ]).decode().strip()
+        ], stderr=subprocess.PIPE).decode().strip()
         # Get a 12-hour auth token for CodeArtifact.
         # This uses the Batch job's IAM role (no explicit credentials needed).
-        token = sp.check_output([
+        token = subprocess.check_output([
             'aws', 'codeartifact', 'get-authorization-token',
             '--domain', domain, '--domain-owner', owner,
             '--query', 'authorizationToken', '--output', 'text',
             '--region', region
-        ]).decode().strip()
+        ], stderr=subprocess.PIPE).decode().strip()
 
         # Get the HTTPS endpoint URL for the maven-cache repository.
         # This is what Maven will use instead of https://repo.maven.apache.org/maven2
-        endpoint = sp.check_output([
+        endpoint = subprocess.check_output([
             'aws', 'codeartifact', 'get-repository-endpoint',
             '--domain', domain, '--domain-owner', owner,
             '--repository', repo, '--format', 'maven',
             '--query', 'repositoryEndpoint', '--output', 'text',
             '--region', region
-        ]).decode().strip()
-    except (sp.CalledProcessError, FileNotFoundError):
+        ], stderr=subprocess.PIPE).decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
         # CalledProcessError: AWS CLI failed (missing permissions, no CodeArtifact)
         # FileNotFoundError: AWS CLI not installed (local dev without AWS CLI)
-        print("WARNING: Could not configure CodeArtifact mirror, "
+        print(f"WARNING: Could not configure CodeArtifact mirror ({e}), "
               "falling back to Maven Central directly")
+        if hasattr(e, 'stderr') and e.stderr:
+            print(f"  stderr: {e.stderr.decode().strip()}")
+        if hasattr(e, 'stdout') and e.stdout:
+            print(f"  stdout: {e.stdout.decode().strip()}")
         return
 
     # Write Maven settings.xml that redirects all "central" repo requests
@@ -266,7 +269,7 @@ def _run_mvn_with_retry(mvn_cmd, max_attempts=3, wait_secs=60):
         try:
             run(mvn_cmd)
             return
-        except subprocess.CalledProcessError:
+        except Exception:
             if attempt == max_attempts:
                 raise
             print(f"\n*** Maven failed (attempt {attempt}/{max_attempts}), "

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -272,7 +272,6 @@ def _run_mvn_with_retry(mvn_cmd, max_attempts=3, wait_secs=60):
             print(f"\n*** Maven failed (attempt {attempt}/{max_attempts}), "
                   f"retrying in {wait_secs}s...")
             time.sleep(wait_secs)
-            time.sleep(wait_secs)
 
 
 def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -4,6 +4,7 @@ But scripts/build-runner.py is the main one you'd call from the terminal.
 """
 import os
 from pathlib import Path
+import subprocess
 import sys
 from typing import Optional
 
@@ -256,6 +257,24 @@ def _setup_maven_codeartifact():
     print(f"Configured Maven to use CodeArtifact mirror: {endpoint}")
 
 
+def _run_mvn_with_retry(mvn_cmd, max_attempts=3, wait_secs=60):
+    """Run a Maven command with retry logic for transient failures (e.g. 403 from Maven Central).
+    If CodeArtifact is configured, retries are unlikely to be needed. But if we fall back
+    to Maven Central directly, this provides resilience against rate limiting."""
+    import time
+    for attempt in range(1, max_attempts + 1):
+        try:
+            run(mvn_cmd)
+            return
+        except subprocess.CalledProcessError:
+            if attempt == max_attempts:
+                raise
+            print(f"\n*** Maven failed (attempt {attempt}/{max_attempts}), "
+                  f"retrying in {wait_secs}s...")
+            time.sleep(wait_secs)
+            time.sleep(wait_secs)
+
+
 def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
     """build s3-benchrunner-java"""
 
@@ -267,7 +286,7 @@ def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
                    dir=awscrt_src,
                    preferred_branch=branch)
     os.chdir(str(awscrt_src))
-    run(['mvn', 'clean', 'install', '-Dmaven.test.skip'])
+    _run_mvn_with_retry(['mvn', 'clean', 'install', '-Dmaven.test.skip'])
 
     # fetch latest aws-sdk-java-v2 and install latest SNAPSHOT version
     sdk_src = work_dir/'aws-sdk-java-v2'
@@ -276,7 +295,7 @@ def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
                    main_branch='master',
                    preferred_branch=branch)
     os.chdir(str(sdk_src))
-    run(['mvn', 'clean', 'install',
+    _run_mvn_with_retry(['mvn', 'clean', 'install',
          '--projects', ':s3-transfer-manager,:s3,:bom-internal,:bom',
          '--activate-profiles', 'quick',
          '--also-make',
@@ -287,7 +306,7 @@ def _build_java(work_dir: Path, branch: Optional[str]) -> list[str]:
     # Build runner
     runner_src = RUNNERS['java'].dir
     os.chdir(str(runner_src))
-    run(['mvn',
+    _run_mvn_with_retry(['mvn',
          'clean',
          # package along with dependencies in executable uber-java
          'package',

--- a/scripts/utils/build.py
+++ b/scripts/utils/build.py
@@ -4,7 +4,7 @@ But scripts/build-runner.py is the main one you'd call from the terminal.
 """
 import os
 from pathlib import Path
-import subprocess
+import shutil
 import sys
 from typing import Optional
 
@@ -125,10 +125,12 @@ def _build_python(work_dir: Path, branch: Optional[str]) -> list[str]:
 
     # create virtual environment (if necessary) awscli from Github
     # doesn't interfere with system installation of awscli
+    # Use Python 3.11+ for the venv if available (boto3 dropped 3.9 support)
+    venv_python_bin = shutil.which('python3.11') or sys.executable
     venv_dir = work_dir.joinpath('venv')
     venv_python = str(venv_dir.joinpath('bin/python3'))
     if not venv_dir.exists():
-        run([sys.executable, '-m', 'venv', str(venv_dir)])
+        run([venv_python_bin, '-m', 'venv', str(venv_dir)])
 
         # upgrade pip to avoid warnings
         # and install wheel so we can build aws-crt-python
@@ -190,47 +192,35 @@ def _setup_maven_codeartifact():
     requests (from any job, any day) are served from the cache. Since this is
     AWS-to-AWS traffic within the same account, there's no rate limiting.
 
-    If anything fails Maven will fall back to hitting Central directly.
+    Uses boto3 (already installed via requirements.txt) rather than aws CLI
+    (not available in the container). If anything fails, Maven will fall back
+    to hitting Central directly.
     """
-
     domain = 's3-benchmarks'
     repo = 'maven-cache'
     region = 'us-west-2'
 
     try:
+        import boto3
+
         # Discover the AWS account ID from the Batch job's IAM role.
-        # This avoids hardcoding the account ID in a public repo.
-        owner = subprocess.check_output([
-            'aws', 'sts', 'get-caller-identity',
-            '--query', 'Account', '--output', 'text'
-        ], stderr=subprocess.PIPE).decode().strip()
+        sts = boto3.client('sts', region_name=region)
+        owner = sts.get_caller_identity()['Account']
+
         # Get a 12-hour auth token for CodeArtifact.
-        # This uses the Batch job's IAM role (no explicit credentials needed).
-        token = subprocess.check_output([
-            'aws', 'codeartifact', 'get-authorization-token',
-            '--domain', domain, '--domain-owner', owner,
-            '--query', 'authorizationToken', '--output', 'text',
-            '--region', region
-        ], stderr=subprocess.PIPE).decode().strip()
+        ca = boto3.client('codeartifact', region_name=region)
+        token = ca.get_authorization_token(
+            domain=domain, domainOwner=owner
+        )['authorizationToken']
 
         # Get the HTTPS endpoint URL for the maven-cache repository.
-        # This is what Maven will use instead of https://repo.maven.apache.org/maven2
-        endpoint = subprocess.check_output([
-            'aws', 'codeartifact', 'get-repository-endpoint',
-            '--domain', domain, '--domain-owner', owner,
-            '--repository', repo, '--format', 'maven',
-            '--query', 'repositoryEndpoint', '--output', 'text',
-            '--region', region
-        ], stderr=subprocess.PIPE).decode().strip()
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        # CalledProcessError: AWS CLI failed (missing permissions, no CodeArtifact)
-        # FileNotFoundError: AWS CLI not installed (local dev without AWS CLI)
+        endpoint = ca.get_repository_endpoint(
+            domain=domain, domainOwner=owner,
+            repository=repo, format='maven'
+        )['repositoryEndpoint']
+    except Exception as e:
         print(f"WARNING: Could not configure CodeArtifact mirror ({e}), "
               "falling back to Maven Central directly")
-        if hasattr(e, 'stderr') and e.stderr:
-            print(f"  stderr: {e.stderr.decode().strip()}")
-        if hasattr(e, 'stdout') and e.stdout:
-            print(f"  stdout: {e.stdout.decode().strip()}")
         return
 
     # Write Maven settings.xml that redirects all "central" repo requests
@@ -376,8 +366,6 @@ def _build_rclone(work_dir: Path, branch: Optional[str]) -> list[str]:
         print("WARNING: rclone runner doesn't currently support --branch")
 
     # Check if rclone is already in PATH
-    import shutil
-
     rclone_path = shutil.which('rclone')
 
     if not rclone_path:


### PR DESCRIPTION
- Wrap each individual client's build/run in a try/except to allow other clients to continue. Currently Java failing due to maven related errors are preventing other clients from executing their benchmarks.
- Track failed languages to skip related language clients and to print a summary of failed clients at end. We still exit with code 1 if any client failed to preserve visibility.
- Use CodeArtifact as a caching proxy for Maven Central. The reason why Java was failing was due to 403s from rate limiting. If CodeArtifact is unavailable we fall back gracefully to using Maven Central as we were before.
- Add a retry for Maven commands to provide resilience in the event the CodeArtifact fails and we need to use Maven.
- Install and use Python 3.11 because Boto3 is dropping support for Python 3.9


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
