### PR TITLE
Standardize output to json

### DIFF
--- a/runners/s3-benchrunner-3p/main.py
+++ b/runners/s3-benchrunner-3p/main.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import argparse
+import json
+import resource
+import statistics
 import time
 
 from runner import (
@@ -36,6 +39,20 @@ def create_runner(config: BenchmarkConfig, s3_client: str, executable_path: str)
         raise ValueError(f'Unknown S3 client: {s3_client}')
 
 
+def _calc_stats(values: list[float]) -> dict:
+    """Compute median, mean, min, max, stddev for a list of values."""
+    sorted_v = sorted(values)
+    n = len(sorted_v)
+    mean = statistics.mean(sorted_v)
+    return {
+        "median": round(statistics.median(sorted_v), 6),
+        "mean": round(mean, 6),
+        "min": round(sorted_v[0], 6),
+        "max": round(sorted_v[-1], 6),
+        "stddev": round(statistics.pstdev(sorted_v), 6),
+    }
+
+
 if __name__ == '__main__':
     args = PARSER.parse_args()
     config = BenchmarkConfig(args.WORKLOAD, args.BUCKET, args.REGION,
@@ -47,6 +64,7 @@ if __name__ == '__main__':
     bytes_per_run = config.bytes_per_run()
 
     # Repeat benchmark until we exceed max_repeat_count or max_repeat_secs
+    durations = []
     app_start_ns = time.perf_counter_ns()
     for run_i in range(config.max_repeat_count):
         runner.prepare_run()
@@ -56,6 +74,7 @@ if __name__ == '__main__':
         runner.run()
 
         run_secs = ns_to_secs(time.perf_counter_ns() - run_start_ns)
+        durations.append(run_secs)
         print(f'Run:{run_i+1} ' +
               f'Secs:{run_secs:f} ' +
               f'Gb/s:{bytes_to_gigabit(bytes_per_run) / run_secs:f}',
@@ -65,3 +84,22 @@ if __name__ == '__main__':
         app_secs = ns_to_secs(time.perf_counter_ns() - app_start_ns)
         if app_secs >= config.max_repeat_secs:
             break
+
+    # Print standardized STATS JSON
+    if durations:
+        throughputs = [bytes_to_gigabit(bytes_per_run) / s for s in durations]
+        # ru_maxrss from child processes (the 3P tools run as subprocesses)
+        peak_rss_kib = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+        import sys
+        if sys.platform == 'darwin':
+            peak_rss_mib = peak_rss_kib / (1024 * 1024)
+        else:
+            peak_rss_mib = peak_rss_kib / 1024
+        stats = {
+            "runs": len(durations),
+            "bytes_per_run": bytes_per_run,
+            "peak_rss_mib": round(peak_rss_mib, 1),
+            "duration": _calc_stats(durations),
+            "throughput_gbps": _calc_stats(throughputs),
+        }
+        print(f"STATS:{json.dumps(stats)}", flush=True)

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -1,6 +1,7 @@
 #include "BenchmarkRunner.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -203,8 +204,16 @@ template <typename... Args> void StatsPrintf(const char *fmt, Args... args)
     }
 }
 
-// Print all kinds of stats about these values (median, mean, min, max, etc)
-void printValueStats(const char *label, vector<double> values)
+struct ValueStats
+{
+    double median;
+    double mean;
+    double min;
+    double max;
+    double stddev;
+};
+
+ValueStats computeStats(vector<double> values)
 {
     std::sort(values.begin(), values.end());
     double n = values.size();
@@ -218,15 +227,11 @@ void printValueStats(const char *label, vector<double> values)
         size_t middle = values.size() / 2;
         if (values.size() % 2 == 1)
         {
-            // odd number, use middle value
             median = values[middle];
         }
         else
         {
-            // even number, use avg of two middle values
-            double a = values[middle - 1];
-            double b = values[middle];
-            median = (a + b) / 2;
+            median = (values[middle - 1] + values[middle]) / 2;
         }
     }
 
@@ -236,17 +241,7 @@ void printValueStats(const char *label, vector<double> values)
         0.0,
         [mean, n](double accumulator, const double &val) { return accumulator + ((val - mean) * (val - mean) / n); });
 
-    double stdDev = std::sqrt(variance);
-
-    StatsPrintf(
-        "Overall %s Median:%f Mean:%f Min:%f Max:%f Variance:%f StdDev:%f\n",
-        label,
-        median,
-        mean,
-        min,
-        max,
-        variance,
-        stdDev);
+    return {median, mean, min, max, std::sqrt(variance)};
 }
 
 void printAllStats(uint64_t bytesPerRun, const vector<double> &durations)
@@ -255,14 +250,24 @@ void printAllStats(uint64_t bytesPerRun, const vector<double> &durations)
     for (double duration : durations)
         throughputsGbps.push_back(bytesToGigabit(bytesPerRun) / duration);
 
-    printValueStats("Throughput (Gb/s)", throughputsGbps);
-
-    printValueStats("Duration (Secs)", durations);
+    ValueStats tStats = computeStats(throughputsGbps);
+    ValueStats dStats = computeStats(durations);
 
     struct aws_memory_usage_stats mu;
     aws_init_memory_usage_for_current_process(&mu);
+    double peakRssMiB = (double)mu.maxrss / 1024.0;
 
-    StatsPrintf("Peak RSS:%f MiB\n", (double)mu.maxrss / 1024.0);
+    // Standardized JSON stats line, parsed by the benchmark harness
+    StatsPrintf(
+        "STATS:{\"runs\":%zu,\"bytes_per_run\":%" PRIu64
+        ",\"peak_rss_mib\":%.1f"
+        ",\"duration\":{\"median\":%.6f,\"mean\":%.6f,\"min\":%.6f,\"max\":%.6f,\"stddev\":%.6f}"
+        ",\"throughput_gbps\":{\"median\":%.6f,\"mean\":%.6f,\"min\":%.6f,\"max\":%.6f,\"stddev\":%.6f}}\n",
+        durations.size(),
+        bytesPerRun,
+        peakRssMiB,
+        dStats.median, dStats.mean, dStats.min, dStats.max, dStats.stddev,
+        tStats.median, tStats.mean, tStats.min, tStats.max, tStats.stddev);
 }
 
 /**

--- a/runners/s3-benchrunner-c/BenchmarkRunner.cpp
+++ b/runners/s3-benchrunner-c/BenchmarkRunner.cpp
@@ -259,15 +259,22 @@ void printAllStats(uint64_t bytesPerRun, const vector<double> &durations)
 
     // Standardized JSON stats line, parsed by the benchmark harness
     StatsPrintf(
-        "STATS:{\"runs\":%zu,\"bytes_per_run\":%" PRIu64
-        ",\"peak_rss_mib\":%.1f"
+        "STATS:{\"runs\":%zu,\"bytes_per_run\":%" PRIu64 ",\"peak_rss_mib\":%.1f"
         ",\"duration\":{\"median\":%.6f,\"mean\":%.6f,\"min\":%.6f,\"max\":%.6f,\"stddev\":%.6f}"
         ",\"throughput_gbps\":{\"median\":%.6f,\"mean\":%.6f,\"min\":%.6f,\"max\":%.6f,\"stddev\":%.6f}}\n",
         durations.size(),
         bytesPerRun,
         peakRssMiB,
-        dStats.median, dStats.mean, dStats.min, dStats.max, dStats.stddev,
-        tStats.median, tStats.mean, tStats.min, tStats.max, tStats.stddev);
+        dStats.median,
+        dStats.mean,
+        dStats.min,
+        dStats.max,
+        dStats.stddev,
+        tStats.median,
+        tStats.mean,
+        tStats.min,
+        tStats.max,
+        tStats.stddev);
 }
 
 /**

--- a/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/Main.java
+++ b/runners/s3-benchrunner-java/src/main/java/com/example/s3benchrunner/Main.java
@@ -18,26 +18,62 @@ public class Main {
     /////////////// END ARBITRARY HARD-CODED VALUES ///////////////
 
     private static void printStats(long bytesPerRun, List<Double> durations) {
-        double n = durations.size();
-        double durationMean = 0;
-        for (Double duration : durations) {
-            durationMean += duration / n;
-        }
+        int n = durations.size();
+        List<Double> sortedDurations = new ArrayList<>(durations);
+        java.util.Collections.sort(sortedDurations);
 
-        double durationVariance = 0;
-        for (Double duration : durations) {
-            durationVariance += (duration - durationMean) * (duration - durationMean) / n;
+        List<Double> throughputs = new ArrayList<>();
+        for (Double d : durations) {
+            throughputs.add(Util.bytesToGigabit(bytesPerRun) / d);
         }
+        List<Double> sortedThroughputs = new ArrayList<>(throughputs);
+        java.util.Collections.sort(sortedThroughputs);
 
-        double mbsMean = Util.bytesToMegabit(bytesPerRun) / durationMean;
-        double mbsVariance = Util.bytesToMegabit(bytesPerRun) / durationVariance;
+        double[] dStats = calcStats(sortedDurations);
+        double[] tStats = calcStats(sortedThroughputs);
+
+        long peakRssKiB = 0;
+        try {
+            // Read peak RSS from /proc/self/status on Linux
+            String status = new String(java.nio.file.Files.readAllBytes(
+                    java.nio.file.Path.of("/proc/self/status")));
+            for (String line : status.split("\n")) {
+                if (line.startsWith("VmHWM:")) {
+                    peakRssKiB = Long.parseLong(line.replaceAll("[^0-9]", ""));
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            // Not on Linux or can't read - use Runtime as fallback
+            Runtime rt = Runtime.getRuntime();
+            peakRssKiB = (rt.totalMemory() - rt.freeMemory()) / 1024;
+        }
+        double peakRssMiB = peakRssKiB / 1024.0;
 
         System.out.printf(
-                "Overall stats; Throughput Mean:%.1f Mb/s Throughput Variance:%.1f Mb/s Duration Mean:%.3f s Duration Variance:%.3f s %n",
-                mbsMean,
-                mbsVariance,
-                durationMean,
-                durationVariance);
+                "STATS:{\"runs\":%d,\"bytes_per_run\":%d,\"peak_rss_mib\":%.1f"
+                        + ",\"duration\":{\"median\":%.6f,\"mean\":%.6f,\"min\":%.6f,\"max\":%.6f,\"stddev\":%.6f}"
+                        + ",\"throughput_gbps\":{\"median\":%.6f,\"mean\":%.6f,\"min\":%.6f,\"max\":%.6f,\"stddev\":%.6f}}%n",
+                n, bytesPerRun, peakRssMiB,
+                dStats[0], dStats[1], dStats[2], dStats[3], dStats[4],
+                tStats[0], tStats[1], tStats[2], tStats[3], tStats[4]);
+    }
+
+    // Returns [median, mean, min, max, stddev]
+    private static double[] calcStats(List<Double> sorted) {
+        int n = sorted.size();
+        double min = sorted.get(0);
+        double max = sorted.get(n - 1);
+        double mean = sorted.stream().mapToDouble(Double::doubleValue).sum() / n;
+        double median;
+        if (n % 2 == 1) {
+            median = sorted.get(n / 2);
+        } else {
+            median = (sorted.get(n / 2 - 1) + sorted.get(n / 2)) / 2.0;
+        }
+        double variance = sorted.stream().mapToDouble(v -> (v - mean) * (v - mean) / n).sum();
+        double stddev = Math.sqrt(variance);
+        return new double[] { median, mean, min, max, stddev };
     }
 
     public static void main(String[] args) throws Exception {

--- a/runners/s3-benchrunner-python/main.py
+++ b/runners/s3-benchrunner-python/main.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import argparse
+import json
+import resource
+import statistics
 import time
 
 from runner import (
@@ -41,6 +44,20 @@ def create_runner_given_s3_client_id(id: str, config: BenchmarkConfig) -> Benchm
         raise ValueError(f'Unknown S3 client: {id}')
 
 
+def _calc_stats(values: list[float]) -> dict:
+    """Compute median, mean, min, max, stddev for a list of values."""
+    sorted_v = sorted(values)
+    n = len(sorted_v)
+    mean = statistics.mean(sorted_v)
+    return {
+        "median": round(statistics.median(sorted_v), 6),
+        "mean": round(mean, 6),
+        "min": round(sorted_v[0], 6),
+        "max": round(sorted_v[-1], 6),
+        "stddev": round(statistics.pstdev(sorted_v), 6),
+    }
+
+
 if __name__ == '__main__':
     args = PARSER.parse_args()
     config = BenchmarkConfig(args.WORKLOAD, args.BUCKET, args.REGION,
@@ -52,6 +69,7 @@ if __name__ == '__main__':
     bytes_per_run = config.bytes_per_run()
 
     # Repeat benchmark until we exceed max_repeat_count or max_repeat_secs
+    durations = []
     app_start_ns = time.perf_counter_ns()
     for run_i in range(config.max_repeat_count):
         runner.prepare_run()
@@ -61,6 +79,7 @@ if __name__ == '__main__':
         runner.run()
 
         run_secs = ns_to_secs(time.perf_counter_ns() - run_start_ns)
+        durations.append(run_secs)
         print(f'Run:{run_i+1} ' +
               f'Secs:{run_secs:f} ' +
               f'Gb/s:{bytes_to_gigabit(bytes_per_run) / run_secs:f}',
@@ -70,3 +89,22 @@ if __name__ == '__main__':
         app_secs = ns_to_secs(time.perf_counter_ns() - app_start_ns)
         if app_secs >= config.max_repeat_secs:
             break
+
+    # Print standardized STATS JSON
+    if durations:
+        throughputs = [bytes_to_gigabit(bytes_per_run) / s for s in durations]
+        peak_rss_kib = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # On macOS ru_maxrss is bytes, on Linux it's KiB
+        import sys
+        if sys.platform == 'darwin':
+            peak_rss_mib = peak_rss_kib / (1024 * 1024)
+        else:
+            peak_rss_mib = peak_rss_kib / 1024
+        stats = {
+            "runs": len(durations),
+            "bytes_per_run": bytes_per_run,
+            "peak_rss_mib": round(peak_rss_mib, 1),
+            "duration": _calc_stats(durations),
+            "throughput_gbps": _calc_stats(throughputs),
+        }
+        print(f"STATS:{json.dumps(stats)}", flush=True)

--- a/runners/s3-benchrunner-rust/src/main.rs
+++ b/runners/s3-benchrunner-rust/src/main.rs
@@ -79,6 +79,7 @@ async fn execute(args: &Args) -> Result<()> {
     let gigabits_per_run = bytes_to_gigabits(bytes_per_run);
 
     // repeat benchmark until we exceed max_repeat_count or max_repeat_secs
+    let mut durations: Vec<f64> = Vec::new();
     let app_start = Instant::now();
     for run_num in 1..=workload.max_repeat_count {
         prepare_run(workload)?;
@@ -96,6 +97,7 @@ async fn execute(args: &Args) -> Result<()> {
             .await?;
 
         let run_secs = run_start.elapsed().as_secs_f64();
+        durations.push(run_secs);
 
         // flush any telemetry
         if let Some(telemetry) = &mut telemetry {
@@ -106,7 +108,7 @@ async fn execute(args: &Args) -> Result<()> {
             ));
         }
 
-        eprintln!(
+        println!(
             "Run:{} Secs:{:.6} Gb/s:{:.6}",
             run_num,
             run_secs,
@@ -117,6 +119,25 @@ async fn execute(args: &Args) -> Result<()> {
         if app_start.elapsed().as_secs_f64() >= workload.max_repeat_secs {
             break;
         }
+    }
+
+    // Print standardized STATS JSON
+    if !durations.is_empty() {
+        let throughputs: Vec<f64> = durations.iter().map(|d| gigabits_per_run / d).collect();
+        let d_stats = calc_stats(&durations);
+        let t_stats = calc_stats(&throughputs);
+
+        // Peak RSS from /proc/self/status on Linux
+        let peak_rss_mib = read_peak_rss_mib();
+
+        println!(
+            "STATS:{{\"runs\":{},\"bytes_per_run\":{},\"peak_rss_mib\":{:.1}\
+             ,\"duration\":{{\"median\":{:.6},\"mean\":{:.6},\"min\":{:.6},\"max\":{:.6},\"stddev\":{:.6}}}\
+             ,\"throughput_gbps\":{{\"median\":{:.6},\"mean\":{:.6},\"min\":{:.6},\"max\":{:.6},\"stddev\":{:.6}}}}}",
+            durations.len(), bytes_per_run, peak_rss_mib,
+            d_stats.0, d_stats.1, d_stats.2, d_stats.3, d_stats.4,
+            t_stats.0, t_stats.1, t_stats.2, t_stats.3, t_stats.4,
+        );
     }
 
     Ok(())
@@ -152,4 +173,38 @@ fn trace_file_name(
 ) -> String {
     let run_start = run_start.format("%Y%m%dT%H%M%SZ").to_string();
     format!("trace_{run_start}_{workload}_run{run_num:02}.json")
+}
+
+/// Returns (median, mean, min, max, stddev)
+fn calc_stats(values: &[f64]) -> (f64, f64, f64, f64, f64) {
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = sorted.len() as f64;
+    let min = sorted[0];
+    let max = sorted[sorted.len() - 1];
+    let mean = sorted.iter().sum::<f64>() / n;
+    let median = if sorted.len() % 2 == 1 {
+        sorted[sorted.len() / 2]
+    } else {
+        (sorted[sorted.len() / 2 - 1] + sorted[sorted.len() / 2]) / 2.0
+    };
+    let variance = sorted.iter().map(|v| (v - mean).powi(2) / n).sum::<f64>();
+    let stddev = variance.sqrt();
+    (median, mean, min, max, stddev)
+}
+
+fn read_peak_rss_mib() -> f64 {
+    // Try /proc/self/status (Linux)
+    if let Ok(contents) = std::fs::read_to_string("/proc/self/status") {
+        for line in contents.lines() {
+            if line.starts_with("VmHWM:") {
+                if let Some(kb_str) = line.split_whitespace().nth(1) {
+                    if let Ok(kb) = kb_str.parse::<f64>() {
+                        return kb / 1024.0;
+                    }
+                }
+            }
+        }
+    }
+    0.0
 }


### PR DESCRIPTION
Standardize runners to output json output after completing their run loops instead of free-form text that was varied across the runners.

C/C++: Replaced printValueStats() free-form output with structured STATS:{json} (same data, machine-parseable format)
Java: Replaced printStats() which incorrectly reported in Mb/s with full stats in Gb/s via STATS:{json}. Added calcStats() helper and peak RSS via /proc/self/status
Python: Added STATS:{json} output with duration/throughput stats and peak RSS via resource.getrusage()
3P: Same as Python, using RUSAGE_CHILDREN to capture subprocess (s5cmd/rclone) RSS
Rust: Fixed eprintln! → println! for Run:N lines (was writing to stderr instead of stdout). Added STATS:{json} output with calc_stats() and read_peak_rss_mib() helpers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
